### PR TITLE
refactor: reduce number of greys

### DIFF
--- a/packages/components/src/BlockLink/BlockLink.story.js
+++ b/packages/components/src/BlockLink/BlockLink.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|BlockLink', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <BlockLink href="https://www.qantas.com" target="_blank">
-      <Box p={3} bg="grey.6">
+      <Box p={3} bg="grey.3">
         Hello world
       </Box>
     </BlockLink>

--- a/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
+++ b/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
@@ -5,7 +5,7 @@ exports[`<BlockLink /> renders correctly 1`] = `
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #e00e00;
+  color: #E00E00;
   display: block;
   color: inherit;
   -webkit-text-decoration: none;

--- a/packages/components/src/Box/Box.story.js
+++ b/packages/components/src/Box/Box.story.js
@@ -8,7 +8,7 @@ import README from './README.md';
 storiesOf('Components|Box', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Box p={3} bg="grey.6">
+    <Box p={3} bg="grey.3">
       Hello world
     </Box>
   ));

--- a/packages/components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.js.snap
@@ -35,7 +35,7 @@ exports[`<Button /> primary renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {
@@ -111,7 +111,7 @@ exports[`<Button /> renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {
@@ -187,7 +187,7 @@ exports[`<Button /> rounded renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {

--- a/packages/components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.js.snap
@@ -27,7 +27,7 @@ exports[`<Button /> primary renders correctly 1`] = `
   -moz-appearance: none;
   appearance: none;
   color: white;
-  background-color: #e40000;
+  background-color: #E40000;
 }
 
 .c0:hover:not(:disabled) {

--- a/packages/components/src/Card/Card.story.js
+++ b/packages/components/src/Card/Card.story.js
@@ -9,7 +9,7 @@ import README from './README.md';
 storiesOf('Components|Card', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Box p={5} bg="grey.6">
+    <Box p={5} bg="grey.3">
       <Card>
         Hello world
       </Card>

--- a/packages/components/src/Card/__snapshots__/Card.test.js.snap
+++ b/packages/components/src/Card/__snapshots__/Card.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Card /> renders correctly 1`] = `
 .c0 {
   padding: 1rem;
-  background-color: white;
+  background-color: #FFFFFF;
   box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
   border-radius: 4px;
 }

--- a/packages/components/src/Container/Container.story.js
+++ b/packages/components/src/Container/Container.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|Container', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <Container>
-      <Box p={3} bg="grey.6">
+      <Box p={3} bg="grey.3">
         Hello world
       </Box>
     </Container>

--- a/packages/components/src/Flex/Flex.story.js
+++ b/packages/components/src/Flex/Flex.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|Flex', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <Flex>
-      <Box width={1 / 2} p={3} m={3} bg="grey.6">Flex</Box>
-      <Box width={1 / 2} p={3} m={3} bg="grey.6">Box</Box>
+      <Box width={1 / 2} p={3} m={3} bg="grey.3">Flex</Box>
+      <Box width={1 / 2} p={3} m={3} bg="grey.3">Box</Box>
     </Flex>
   ));

--- a/packages/components/src/Heading/__snapshots__/Heading.test.js.snap
+++ b/packages/components/src/Heading/__snapshots__/Heading.test.js.snap
@@ -12,7 +12,7 @@ exports[`<Heading /> <Heading.h1 /> renders correctly 1`] = `
 
 <h1
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="3xl"
   fontWeight="bold"
 >
@@ -32,7 +32,7 @@ exports[`<Heading /> <Heading.h1 /> renders correctly 2`] = `
 
 <h1
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="3xl"
   fontWeight="bold"
 >
@@ -52,7 +52,7 @@ exports[`<Heading /> <Heading.h2 /> renders correctly 1`] = `
 
 <h2
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="2xl"
   fontWeight="bold"
 >
@@ -72,7 +72,7 @@ exports[`<Heading /> <Heading.h3 /> renders correctly 1`] = `
 
 <h3
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="xl"
   fontWeight="bold"
 >
@@ -92,7 +92,7 @@ exports[`<Heading /> <Heading.h4 /> renders correctly 1`] = `
 
 <h4
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="lg"
   fontWeight="bold"
 >
@@ -112,7 +112,7 @@ exports[`<Heading /> <Heading.h5 /> renders correctly 1`] = `
 
 <h5
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="base"
   fontWeight="bold"
 >
@@ -132,7 +132,7 @@ exports[`<Heading /> <Heading.h6 /> renders correctly 1`] = `
 
 <h6
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="sm"
   fontWeight="bold"
 >
@@ -152,7 +152,7 @@ exports[`<Heading /> renders correctly 1`] = `
 
 <span
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="xl"
   fontWeight="bold"
 >

--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -9,9 +9,9 @@ const Input = styled(tag.input)`
   padding: ${themeGet('space.3')} ${themeGet('space.4')};
   font-size: ${themeGet('fontSizes.base')};
   line-height: ${themeGet('lineHeights.normal')};
-  color: ${themeGet('colors.grey.1')};
+  color: ${themeGet('colors.grey.0')};
   border: ${themeGet('borders.2')};
-  border-color: ${themeGet('colors.grey.5')};
+  border-color: ${themeGet('colors.grey.2')};
   outline: 0;
   appearance: none;
 
@@ -21,7 +21,7 @@ const Input = styled(tag.input)`
   }
 
   ::placeholder {
-    color: ${themeGet('colors.grey.4')};
+    color: ${themeGet('colors.grey.1')};
   }
 
   ::-ms-clear {

--- a/packages/components/src/Input/__snapshots__/Input.test.js.snap
+++ b/packages/components/src/Input/__snapshots__/Input.test.js.snap
@@ -18,23 +18,23 @@ exports[`<Input /> renders correctly 1`] = `
 }
 
 .c0:focus {
-  border-color: #8de2e0;
+  border-color: #8DE2E0;
 }
 
 .c0::-webkit-input-placeholder {
-  color: #7B7B7B;
+  color: #666666;
 }
 
 .c0::-moz-placeholder {
-  color: #7B7B7B;
+  color: #666666;
 }
 
 .c0:-ms-input-placeholder {
-  color: #7B7B7B;
+  color: #666666;
 }
 
 .c0::placeholder {
-  color: #7B7B7B;
+  color: #666666;
 }
 
 .c0::-ms-clear {

--- a/packages/components/src/Label/Label.js
+++ b/packages/components/src/Label/Label.js
@@ -28,7 +28,7 @@ Label.propTypes = {
 Label.defaultProps = {
   fontSize: 'sm',
   fontWeight: 'bold',
-  color: 'grey.1',
+  color: 'grey.0',
   m: 0,
   mb: 3,
   hidden: false,

--- a/packages/components/src/Label/__snapshots__/Label.test.js.snap
+++ b/packages/components/src/Label/__snapshots__/Label.test.js.snap
@@ -26,7 +26,7 @@ exports[`<Label /> hidden renders correctly 1`] = `
 
 <Clean.label
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="sm"
   fontWeight="bold"
   hidden={true}
@@ -51,7 +51,7 @@ exports[`<Label /> renders correctly 1`] = `
 
 <Clean.label
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="sm"
   fontWeight="bold"
   hidden={false}

--- a/packages/components/src/Link/__snapshots__/Link.test.js.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.js.snap
@@ -5,7 +5,7 @@ exports[`<Link /> renders correctly 1`] = `
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #e00e00;
+  color: #E00E00;
 }
 
 .c0:hover {

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -27,9 +27,9 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
   -moz-appearance: none;
   appearance: none;
   color: white;
-  background-color: #e40000;
+  background-color: #E40000;
   background-color: transparent;
-  border-color: #e40000;
+  border-color: #E40000;
   -webkit-transition: none;
   transition: none;
 }
@@ -49,12 +49,12 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 
 .c0:not(:hover),
 .c0:disabled {
-  color: #e40000;
+  color: #E40000;
 }
 
 .c0:hover:not(:disabled) {
-  background-color: #e40000;
-  border-color: #e40000;
+  background-color: #E40000;
+  border-color: #E40000;
 }
 
 <Clean.button

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -39,7 +39,7 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {
@@ -129,7 +129,7 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {
@@ -219,7 +219,7 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px undefined;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .c0:disabled {

--- a/packages/components/src/Text/Text.js
+++ b/packages/components/src/Text/Text.js
@@ -32,7 +32,7 @@ Text.propTypes = {
 
 Text.defaultProps = {
   fontSize: 'base',
-  color: 'grey.1',
+  color: 'grey.0',
   lineHeight: 'loose',
   fontWeight: 'normal',
   m: 0,

--- a/packages/components/src/Text/__snapshots__/Text.test.js.snap
+++ b/packages/components/src/Text/__snapshots__/Text.test.js.snap
@@ -12,7 +12,7 @@ exports[`<Text /> renders correctly 1`] = `
 
 <Clean.p
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="base"
   fontWeight="normal"
   lineHeight="loose"

--- a/packages/components/src/Truncate/__snapshots__/Truncate.test.js.snap
+++ b/packages/components/src/Truncate/__snapshots__/Truncate.test.js.snap
@@ -15,7 +15,7 @@ exports[`<Truncate /> renders correctly 1`] = `
 
 <Clean.p
   className="c0"
-  color="grey.1"
+  color="grey.0"
   fontSize="base"
   fontWeight="normal"
   lineHeight="loose"

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -2,46 +2,30 @@ import { rem } from 'polished';
 
 const colors = {
   brand: {
-    primary: '#e40000',
-    secondary: '#8de2e0',
+    primary: '#E40000',
+    secondary: '#8DE2E0',
     tertiary: '#D20000',
     quaternary: '#F9F3E9',
   },
   ui: {
-    link: '#e00e00',
+    link: '#E00E00',
     linkHover: '#870000',
-    info: '#8de2e0',
-    infoBackground: '#bff4f2',
-    error: '#ed710b',
-    errorBackground: '#fcebcd',
-    success: '#35a509',
+    info: '#8DE2E0',
+    infoBackground: '#BFF4F2',
+    error: '#ED710B',
+    errorBackground: '#FCEBCD',
+    success: '#35A509',
     successBackground: '#DEF2DE',
   },
   grey: [
-    '#161616',
     '#323232',
-    '#555555',
     '#666666',
-    '#7B7B7B',
     '#DADADA',
     '#F4F5F6',
-    '#F5F5F5',
-    '#FFFFFF',
   ],
+  white: '#FFFFFF',
 };
 
-const borders = [
-  0,
-  '1px solid',
-  '2px solid',
-  '3px solid',
-];
-
-const radii = {
-  none: 0,
-  default: '4px',
-  rounded: '1000px',
-};
 
 export default {
   colors,
@@ -62,8 +46,17 @@ export default {
   maxWidths: {
     default: rem('1280px'),
   },
-  borders,
-  radii,
+  borders: [
+    0,
+    '1px solid',
+    '2px solid',
+    '3px solid',
+  ],
+  radii: {
+    none: 0,
+    default: '4px',
+    rounded: '1000px',
+  },
   shadows: {
     none: 0,
     default: '0 1px 1px 0 rgba(0, 0, 0, 0.1)',
@@ -99,7 +92,7 @@ export default {
   buttons: {
     default: {
       color: 'white',
-      backgroundColor: colors.grey[1],
+      backgroundColor: colors.grey[0],
     },
     primary: {
       color: 'white',

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -26,7 +26,6 @@ const colors = {
   white: '#FFFFFF',
 };
 
-
 export default {
   colors,
   breakpoints: ['40rem', '52rem', '64rem'],

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -61,7 +61,7 @@ export default {
     none: 0,
     default: '0 1px 1px 0 rgba(0, 0, 0, 0.1)',
     heavy: '0 2px 2px 0 rgba(0, 0, 0, 0.1)',
-    focus: `0 0 0 2px ${colors.secondary};`,
+    focus: `0 0 0 2px ${colors.brand.secondary};`,
   },
   transitions: {
     default: '200ms ease-in',


### PR DESCRIPTION
Removed greys we're not using, now we only have:

<img width="261" alt="image" src="https://user-images.githubusercontent.com/3889818/39788640-b6f2f320-536e-11e8-880e-8084f0387190.png">
