### PR TITLE
feat: Adds textStyles onto Link

### DIFF
--- a/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
+++ b/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
@@ -27,6 +27,7 @@ exports[`<BlockLink /> renders correctly 1`] = `
       "bg",
       "hover",
       "fontWeight",
+      "textStyle",
       "inline",
     ]
   }

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import tag from 'clean-tag';
-import { color, hover, fontWeight, themeGet } from 'styled-system';
+import { color, hover, fontWeight, themeGet, textStyle } from 'styled-system';
 
 const Link = styled(tag.a)`
   cursor: pointer;
@@ -19,6 +19,7 @@ const Link = styled(tag.a)`
   ${color}
   ${hover}
   ${fontWeight}
+  ${textStyle}
 
   ${props => props.inline && css`
     &, &:hover {
@@ -32,6 +33,7 @@ Link.propTypes = {
   ...color.propTypes,
   ...hover.propTypes,
   ...fontWeight.propTypes,
+  ...textStyle.propTypes,
   inline: PropTypes.bool,
 };
 

--- a/packages/components/src/Link/README.md
+++ b/packages/components/src/Link/README.md
@@ -39,4 +39,4 @@ export default (
 
 ## Customization
 
-This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for [color](https://github.com/jxnblk/styled-system#color-responsive), [hover](https://github.com/jxnblk/styled-system#hover), or [font weight](https://github.com/jxnblk/styled-system#typography).
+This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for [color](https://github.com/jxnblk/styled-system#color-responsive), [textStyle](https://github.com/jxnblk/styled-system#complex-styles), [hover](https://github.com/jxnblk/styled-system#hover), or [font weight](https://github.com/jxnblk/styled-system#typography).

--- a/packages/components/src/Link/__snapshots__/Link.test.js.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.js.snap
@@ -23,6 +23,7 @@ exports[`<Link /> renders correctly 1`] = `
       "bg",
       "hover",
       "fontWeight",
+      "textStyle",
       "inline",
     ]
   }


### PR DESCRIPTION
### What

As it says on the box.

### Usage example

`<Link href='#content' textStyle='visuallyHidden'>Skip Global Header to Content</Link>`