### PR TITLE
fix: refine circle half icon

### DIFF
--- a/packages/icons/src/rating/circle_half.svg
+++ b/packages/icons/src/rating/circle_half.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm1 2.07c3.94.49 7 3.85 7 7.93s-3.05 7.44-7 7.93V2.07z" fill="none" fill-rule="evenodd"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,17.93V4.07a7.93,7.93,0,0,1,0,15.86Z"/></svg>


### PR DESCRIPTION
### What

Circle half icon not centred in bounding box after sketch export. See gif


![circle-half](https://user-images.githubusercontent.com/980047/40345563-0a327628-5ddd-11e8-9b3c-1eca30712b16.gif)


### Fix

Recreating and exporting via Illustrator solves the alignment problem.

