### PR TITLE
feat: add read only input style

### DIFF
--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -22,6 +22,12 @@ const Input = styled(tag.input)`
     border-color: ${themeGet('colors.brand.secondary')};
   }
 
+  &[readonly] {
+    border-color: transparent;
+    background: transparent;
+    padding-left: 0;
+  }
+
   ::placeholder {
     color: ${themeGet('colors.grey.1')};
   }

--- a/packages/components/src/Input/Input.story.js
+++ b/packages/components/src/Input/Input.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
+import { boolean } from '@storybook/addon-knobs/react';
 
 import Input from '.';
 import README from './README.md';
@@ -8,5 +9,9 @@ import README from './README.md';
 storiesOf('Components|Input', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Input placeholder="Hello world" />
+    <Input
+      placeholder="Hello world"
+      error={boolean('Error', false)}
+      readOnly={boolean('Read only', false)}
+    />
   ));

--- a/packages/components/src/Input/__snapshots__/Input.test.js.snap
+++ b/packages/components/src/Input/__snapshots__/Input.test.js.snap
@@ -24,6 +24,12 @@ exports[`<Input /> renders correctly 1`] = `
   border-color: #8DE2E0;
 }
 
+.c0[readonly] {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
 .c0::-webkit-input-placeholder {
   color: #666666;
 }

--- a/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -24,6 +24,12 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   border-color: #8DE2E0;
 }
 
+.c0[readonly] {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
 .c0::-webkit-input-placeholder {
   color: #666666;
 }
@@ -103,6 +109,12 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
 
 .c0:focus {
   border-color: #8DE2E0;
+}
+
+.c0[readonly] {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
 }
 
 .c0::-webkit-input-placeholder {


### PR DESCRIPTION
**What**

Add's a style for read only inputs. Loses background & border colours and is left aligned to label.
See the email input in the image below.

<img width="313" alt="screen shot 2018-05-23 at 4 27 53 pm" src="https://user-images.githubusercontent.com/2561365/40407322-61d7f414-5ea7-11e8-9d8c-256108d18fb5.png">

