### PR TITLE
chore: add underlined input variant

### DIFF
--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -36,6 +36,12 @@ const Input = styled(tag.input)`
     display: none;
   }
 
+  ${props => props.underline && css`
+    border: none;
+    border-bottom: ${themeGet('borders.2')};
+    border-color: ${themeGet('colors.grey.2')};
+  `}
+
   ${props => props.error && css`
     border-color: ${themeGet('colors.ui.error')};
   `}
@@ -46,6 +52,7 @@ const Input = styled(tag.input)`
 Input.propTypes = {
   ...space.propTypes,
   error: PropTypes.bool,
+  underline: PropTypes.bool,
 };
 
 Input.defaultProps = {

--- a/packages/components/src/Input/Input.story.js
+++ b/packages/components/src/Input/Input.story.js
@@ -12,6 +12,7 @@ storiesOf('Components|Input', module)
     <Input
       placeholder="Hello world"
       error={boolean('Error', false)}
+      underline={boolean('Underline', false)}
       readOnly={boolean('Read only', false)}
     />
   ));

--- a/packages/components/src/Input/__snapshots__/Input.test.js.snap
+++ b/packages/components/src/Input/__snapshots__/Input.test.js.snap
@@ -68,6 +68,7 @@ exports[`<Input /> renders correctly 1`] = `
       "px",
       "py",
       "error",
+      "underline",
     ]
   }
   className="c0"

--- a/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -69,6 +69,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
         "px",
         "py",
         "error",
+        "underline",
       ]
     }
     className="c0"
@@ -156,6 +157,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
         "px",
         "py",
         "error",
+        "underline",
       ]
     }
     className="c0"

--- a/packages/components/src/Select/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.js.snap
@@ -71,6 +71,7 @@ exports[`<Select /> renders correctly 1`] = `
       "px",
       "py",
       "error",
+      "underline",
     ]
   }
   className="c0"

--- a/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
@@ -69,6 +69,7 @@ exports[`<Textarea /> renders correctly 1`] = `
       "px",
       "py",
       "error",
+      "underline",
     ]
   }
   className="c0"


### PR DESCRIPTION
TODO: Update snapshots for `Textarea` and `Select`(?) once respective branches are merged in.