### PR TITLE
fix: revert masked input workaround

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.js
+++ b/packages/components/src/Autocomplete/Autocomplete.js
@@ -18,6 +18,7 @@ const Menu = Box.extend`
   margin-top: -${themeGet('space.3')};
   border-left: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
   border-right: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
+  z-index: 2;
 `;
 Menu.displayName = 'Menu';
 

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
@@ -429,6 +429,7 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
   position: absolute;
   width: 100%;
   margin-top: -;
+  z-index: 2;
 }
 
 .c4 {

--- a/packages/components/src/MaskedInput/MaskedInput.js
+++ b/packages/components/src/MaskedInput/MaskedInput.js
@@ -1,27 +1,9 @@
-import React from 'react';
 import TextMask from 'react-text-mask';
-import cleanElement from 'clean-element';
 
 import { Input } from '..';
 
-const CleanInput = cleanElement('input');
-
-CleanInput.propTypes = {
-  ...Input.propTypes,
-};
-
 const MaskedInput = Input.withComponent(TextMask);
 MaskedInput.displayName = 'MaskedInput';
-MaskedInput.defaultProps = {
-  ...Input.defaultProps,
-  render: (ref, { defaultValue, ...props }) => (
-    <CleanInput
-      ref={ref}
-      value={defaultValue}
-      {...props}
-    />
-  ),
-};
 
 MaskedInput.time = MaskedInput.extend``;
 MaskedInput.time.displayName = 'MaskedInput.time';

--- a/packages/components/src/MaskedInput/MaskedInput.js
+++ b/packages/components/src/MaskedInput/MaskedInput.js
@@ -1,16 +1,26 @@
+import React from 'react';
 import TextMask from 'react-text-mask';
+import cleanElement from 'clean-element';
 
 import { Input } from '..';
 
+const CleanInput = cleanElement('input');
+
+CleanInput.propTypes = Input.propTypes;
+
 const MaskedInput = Input.withComponent(TextMask);
 MaskedInput.displayName = 'MaskedInput';
+MaskedInput.defaultProps = {
+  render: (ref, props) => (
+    <CleanInput ref={ref} {...props} />
+  ),
+};
 
 MaskedInput.time = MaskedInput.extend``;
 MaskedInput.time.displayName = 'MaskedInput.time';
 MaskedInput.time.defaultProps = {
-  ...MaskedInput.defaultProps,
   keepCharPositions: true,
-  placeholderChar: '\u2001',
+  placeholderChar: '\u2000',
   mask: [/[0-2]/, /[0-9]/, ':', /[0-6]/, /[0-9]/, ' AEST'],
   placeholder: '00:00 AEST',
 };

--- a/packages/components/src/MaskedInput/MaskedInput.js
+++ b/packages/components/src/MaskedInput/MaskedInput.js
@@ -1,9 +1,27 @@
+import React from 'react';
 import TextMask from 'react-text-mask';
+import cleanElement from 'clean-element';
 
 import { Input } from '..';
 
+const CleanInput = cleanElement('input');
+
+CleanInput.propTypes = {
+  ...Input.propTypes,
+};
+
 const MaskedInput = Input.withComponent(TextMask);
 MaskedInput.displayName = 'MaskedInput';
+MaskedInput.defaultProps = {
+  ...Input.defaultProps,
+  render: (ref, { defaultValue, ...props }) => (
+    <CleanInput
+      ref={ref}
+      value={defaultValue}
+      {...props}
+    />
+  ),
+};
 
 MaskedInput.time = MaskedInput.extend``;
 MaskedInput.time.displayName = 'MaskedInput.time';

--- a/packages/components/src/MaskedInput/MaskedInput.story.js
+++ b/packages/components/src/MaskedInput/MaskedInput.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
-import { boolean } from '@storybook/addon-knobs/react';
 
 import MaskedInput from '.';
 import README from './README.md';
@@ -12,7 +11,6 @@ storiesOf('Components|MaskedInput', module)
     <MaskedInput
       placeholder="Enter postcode"
       mask={[/\d/, /\d/, /\d/, /\d/]}
-      underline={boolean('Underline', false)}
     />
   ))
   .add('time', () => (

--- a/packages/components/src/MaskedInput/MaskedInput.story.js
+++ b/packages/components/src/MaskedInput/MaskedInput.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
+import { boolean } from '@storybook/addon-knobs/react';
 
 import MaskedInput from '.';
 import README from './README.md';
@@ -11,6 +12,7 @@ storiesOf('Components|MaskedInput', module)
     <MaskedInput
       placeholder="Enter postcode"
       mask={[/\d/, /\d/, /\d/, /\d/]}
+      underline={boolean('Underline', false)}
     />
   ))
   .add('time', () => (

--- a/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
+++ b/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
@@ -52,26 +52,6 @@ exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
 }
 
 <t
-  blacklist={
-    Array [
-      "m",
-      "mt",
-      "mr",
-      "mb",
-      "ml",
-      "mx",
-      "my",
-      "p",
-      "pt",
-      "pr",
-      "pb",
-      "pl",
-      "px",
-      "py",
-      "error",
-      "underline",
-    ]
-  }
   className="c0"
   keepCharPositions={true}
   mask={
@@ -85,7 +65,7 @@ exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
     ]
   }
   placeholder="00:00 AEST"
-  placeholderChar=" "
+  placeholderChar=" "
   render={[Function]}
 />
 `;
@@ -142,26 +122,6 @@ exports[`<MaskedInput /> renders correctly 1`] = `
 }
 
 <t
-  blacklist={
-    Array [
-      "m",
-      "mt",
-      "mr",
-      "mb",
-      "ml",
-      "mx",
-      "my",
-      "p",
-      "pt",
-      "pr",
-      "pb",
-      "pl",
-      "px",
-      "py",
-      "error",
-      "underline",
-    ]
-  }
   className="c0"
   id="postcode"
   mask={


### PR DESCRIPTION
- reverts masked input workaround
- fixes props passed into `MaskedInput` as attributes
- changes `MaskedInput` placeholderChar to `\u2000`
- add z-index to `Autocomplete` menu item to display over `Radio`