### PR TITLE
refactor: add maxHeight to Autocomplete menu

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.js
+++ b/packages/components/src/Autocomplete/Autocomplete.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Downshift from 'downshift';
 import { themeGet } from 'styled-system';
 import { css } from 'styled-components';
+import { rem } from 'polished';
 import lowerCase from 'lodash/lowerCase';
 import omit from 'lodash/omit';
 
@@ -19,6 +20,9 @@ const Menu = Box.extend`
   border-left: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
   border-right: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
   z-index: 2;
+  max-height: ${rem('230px')};
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 `;
 Menu.displayName = 'Menu';
 

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
@@ -397,6 +397,9 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
   width: 100%;
   margin-top: -;
   z-index: 2;
+  max-height: 14.375rem;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .c4 {


### PR DESCRIPTION
- Limits `Autocomplete` menu to five items.

![limit](https://media.giphy.com/media/6YGOL2IxyaYqk/giphy.gif)