### PR TITLE
refactor: loading indicator tweaks

### DIFF
--- a/packages/components/src/LoadingIndicator/LoadingIndicator.js
+++ b/packages/components/src/LoadingIndicator/LoadingIndicator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import tag from 'clean-tag';
 import PropTypes from 'prop-types';
-import { color, size } from 'styled-system';
+import { color, size, width, themeGet } from 'styled-system';
 import styled, { keyframes, css } from 'styled-components';
 import Box from '../Box';
 
@@ -16,11 +16,14 @@ const bounce = keyframes`
 `;
 
 const Bouncers = styled(Box)`
+  animation: ${fadeIn} ${themeGet('transitions.default')} both;
+  animation-delay: ${props => props.delay};
+  margin: 0 auto;
   text-align: center;
-  animation: ${fadeIn} 1s ease-in-out both;
-  ${props => css`
-    animation-delay: ${props.delay};
-  `}
+  display: flex;
+  justify-content: space-around;
+
+  ${width}
 `;
 
 const Bouncer = styled(tag.div)`
@@ -28,27 +31,19 @@ const Bouncer = styled(tag.div)`
   border-radius: 100%;
   display: inline-block;
 
+  &:nth-child(1) { animation-delay: -0.32s; }
+  &:nth-child(2) { animation-delay: -0.16s; }
+  &:nth-child(3) { animation-delay: 0; }
+
   ${color}
   ${size}
 `;
 
-const FirstBouncer = Bouncer.extend`
-  animation-delay: -0.32s;
-`;
-
-const SecondBouncer = Bouncer.extend`
-  animation-delay: -0.16s;
-`;
-
-const ThirdBouncer = Bouncer.extend`
-  animation-delay: 0;
-`;
-
 const LoadingIndicator = props => (
-  <Bouncers delay={props.delay}>
-    <FirstBouncer bg={props.color} size={props.size} />
-    <SecondBouncer bg={props.color} size={props.size} />
-    <ThirdBouncer bg={props.color} size={props.size} />
+  <Bouncers delay={props.delay} width={props.size * 4}>
+    <Bouncer bg={props.color} size={props.size} />
+    <Bouncer bg={props.color} size={props.size} />
+    <Bouncer bg={props.color} size={props.size} />
   </Bouncers>
 );
 

--- a/packages/components/src/LoadingIndicator/LoadingIndicator.js
+++ b/packages/components/src/LoadingIndicator/LoadingIndicator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import tag from 'clean-tag';
 import PropTypes from 'prop-types';
 import { color, size, width, themeGet } from 'styled-system';
-import styled, { keyframes, css } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import Box from '../Box';
 
 const fadeIn = keyframes`

--- a/packages/components/src/LoadingIndicator/__snapshots__/LoadingIndicator.test.js.snap
+++ b/packages/components/src/LoadingIndicator/__snapshots__/LoadingIndicator.test.js.snap
@@ -1,17 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['<LoadingIndicator /> matches snapshot 1'] = `
+exports[`<LoadingIndicator /> matches snapshot 1`] = `
 .c0 {
-  text-align: center;
-  -webkit-animation: gdMPTF 1s ease-in-out both;
-  animation: gdMPTF 1s ease-in-out both;
+  -webkit-animation: gdMPTF 200ms ease-in both;
+  animation: gdMPTF 200ms ease-in both;
   -webkit-animation-delay: 0;
   animation-delay: 0;
+  margin: 0 auto;
+  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  width: 72px;
 }
 
 <Box
   className="c0"
   delay="0"
+  width={72}
 >
   <LoadingIndicator__Bouncer
     bg="grey.1"


### PR DESCRIPTION
- Use the theme default transition for fade in; more consistent, and the current fade in feels a bit slow IMO
- Add space between bouncers (consistent with Qantas usage, also looks a little weird currently as the circles are touching at full size)