### PR TITLE
Forward on default props and use Input which is a clean tag element

### DIFF
--- a/packages/components/src/MaskedInput/MaskedInput.js
+++ b/packages/components/src/MaskedInput/MaskedInput.js
@@ -7,9 +7,10 @@ import { Input } from '..';
 const MaskedInput = Input.withComponent(TextMask);
 MaskedInput.displayName = 'MaskedInput';
 MaskedInput.defaultProps = {
+  ...Input.defaultProps,
   render: (ref, { defaultValue, ...props }) => (
-    <input
-      ref={ref}
+    <Input
+      innerRef={ref}
       value={defaultValue}
       {...omit(props, Object.keys(Input.propTypes))}
     />

--- a/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
+++ b/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
@@ -52,7 +52,28 @@ exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
 }
 
 <t
+  blacklist={
+    Array [
+      "m",
+      "mt",
+      "mr",
+      "mb",
+      "ml",
+      "mx",
+      "my",
+      "p",
+      "pt",
+      "pr",
+      "pb",
+      "pl",
+      "px",
+      "py",
+      "error",
+      "underline",
+    ]
+  }
   className="c0"
+  is="input"
   keepCharPositions={true}
   mask={
     Array [
@@ -122,8 +143,29 @@ exports[`<MaskedInput /> renders correctly 1`] = `
 }
 
 <t
+  blacklist={
+    Array [
+      "m",
+      "mt",
+      "mr",
+      "mb",
+      "ml",
+      "mx",
+      "my",
+      "p",
+      "pt",
+      "pr",
+      "pb",
+      "pl",
+      "px",
+      "py",
+      "error",
+      "underline",
+    ]
+  }
   className="c0"
   id="postcode"
+  is="input"
   mask={
     Array [
       /\\\\d/,


### PR DESCRIPTION
Ran into an issue where I wanted to extend `MaskedInput` and add a style based on a prop.

`MaskedInput` was not a `clean-tag` element so it added my prop to the html, which caused React to throw this warning `React does not recognize the "calendarOpen" prop on a DOM element.`

This fix returns our own `Input` component in the render method. This means the input is a `clean-tag` element and we can use the `blacklist` prop. I also forwarded on the `Input` defaultProps, so that  I can extend the `blacklist` and remove the React warning.

@angusfretwell mentioned this could potentially break what you are working on @jonathanly. So would be awesome if you could test this change out in your `Formik` branch.