### PR TITLE
refactor: vertically align inline blocks

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.js
+++ b/packages/components/src/Dropdown/Dropdown.js
@@ -11,6 +11,7 @@ import { Box, NakedButton, Text } from '..';
 const Wrapper = Box.extend`
   position: relative;
   display: inline-block;
+  vertical-align: middle;
 `;
 
 const Toggle = NakedButton.extend`

--- a/packages/components/src/NakedButton/NakedButton.js
+++ b/packages/components/src/NakedButton/NakedButton.js
@@ -16,6 +16,7 @@ const NakedButton = styled(tag.button).attrs({
   line-height: normal;
   appearance: none;
   cursor: pointer;
+  vertical-align: middle;
 
   ${space}
 `;

--- a/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
+++ b/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
@@ -15,6 +15,7 @@ exports[`<NakedButton /> renders correctly 1`] = `
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
+  vertical-align: middle;
 }
 
 <Clean.button


### PR DESCRIPTION
This allows `NakedButton` and `Dropdown` to be correctly vertically centred with flex.

