### PR TITLE
refactor: dont add vertical align to naked button by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "react-text-mask": "^5.4.1",
     "storybook-readme": "^3.2.0",
     "styled-components": "^3.1.5",
+<<<<<<< HEAD
     "styled-system": "^2.3.2"
+=======
+    "styled-system": "^2.3.5"
+>>>>>>> c86ed27... fix: don't vertically align naked button by default
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,6 @@
     "react-text-mask": "^5.4.1",
     "storybook-readme": "^3.2.0",
     "styled-components": "^3.1.5",
-<<<<<<< HEAD
-    "styled-system": "^2.3.2"
-=======
     "styled-system": "^2.3.5"
->>>>>>> c86ed27... fix: don't vertically align naked button by default
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,7 +23,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "styled-components": "^3.1.5",
-    "styled-system": "^2.2.1"
+    "styled-system": "^2.3.5"
   },
   "dependencies": {
     "date-fns": "^1.29.0",

--- a/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -5,6 +5,7 @@ exports[`<CalendarDay /> renders correctly 1`] = `
   <NakedButton
     blacklist={
       Array [
+        "verticalAlign",
         "m",
         "mt",
         "mr",

--- a/packages/components/src/Calendar/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -3,6 +3,11 @@
 exports[`<CalendarNav /> renders correctly 1`] = `
 <Box>
   <NakedButton
+    blacklist={
+      Array [
+        "verticalAlign",
+      ]
+    }
     onClick={[MockFunction]}
   >
     <Icon
@@ -10,6 +15,11 @@ exports[`<CalendarNav /> renders correctly 1`] = `
     />
   </NakedButton>
   <NakedButton
+    blacklist={
+      Array [
+        "verticalAlign",
+      ]
+    }
     onClick={[MockFunction]}
   >
     <Icon

--- a/packages/components/src/Dropdown/Dropdown.js
+++ b/packages/components/src/Dropdown/Dropdown.js
@@ -15,6 +15,8 @@ const Wrapper = Box.extend`
 `;
 
 const Toggle = NakedButton.extend`
+  vertical-align: middle;
+
   &:hover {
     color: ${themeGet('colors.ui.link')};
   }

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -8,6 +8,11 @@ exports[`<Dropdown /> renders correctly when closed 1`] = `
     aria-expanded={false}
     aria-haspopup={true}
     aria-label="open menu"
+    blacklist={
+      Array [
+        "verticalAlign",
+      ]
+    }
     data-toggle={true}
     onBlur={[Function]}
     onClick={[Function]}
@@ -34,6 +39,11 @@ exports[`<Dropdown /> renders correctly when open 1`] = `
     aria-expanded={true}
     aria-haspopup={true}
     aria-label="close menu"
+    blacklist={
+      Array [
+        "verticalAlign",
+      ]
+    }
     data-toggle={true}
     onBlur={[Function]}
     onClick={[Function]}

--- a/packages/components/src/NakedButton/NakedButton.js
+++ b/packages/components/src/NakedButton/NakedButton.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import tag from 'clean-tag';
-import { space } from 'styled-system';
+import { space, verticalAlign } from 'styled-system';
 
 const NakedButton = styled(tag.button).attrs({
   type: 'button',
@@ -16,13 +16,14 @@ const NakedButton = styled(tag.button).attrs({
   line-height: normal;
   appearance: none;
   cursor: pointer;
-  vertical-align: middle;
 
   ${space}
+  ${verticalAlign}
 `;
 
 NakedButton.propTypes = {
   ...space.propTypes,
+  ...verticalAlign.propTypes,
 };
 
 export default NakedButton;

--- a/packages/components/src/NakedButton/NakedButton.js
+++ b/packages/components/src/NakedButton/NakedButton.js
@@ -27,4 +27,8 @@ NakedButton.propTypes = {
   ...space.propTypes,
 };
 
+NakedButton.defaultProps = {
+  blacklist: ['verticalAlign'],
+};
+
 export default NakedButton;

--- a/packages/components/src/NakedButton/NakedButton.js
+++ b/packages/components/src/NakedButton/NakedButton.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import tag from 'clean-tag';
 import { space, verticalAlign } from 'styled-system';
 
@@ -22,8 +23,8 @@ const NakedButton = styled(tag.button).attrs({
 `;
 
 NakedButton.propTypes = {
+  verticalAlign: PropTypes.string,
   ...space.propTypes,
-  ...verticalAlign.propTypes,
 };
 
 export default NakedButton;

--- a/packages/components/src/NakedButton/README.md
+++ b/packages/components/src/NakedButton/README.md
@@ -20,4 +20,4 @@ export default (
 
 ## Customization
 
-This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for [space](https://github.com/jxnblk/styled-system#space-responsive).
+This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for [space](https://jxnblk.com/styled-system/table#core) or [vertical align](https://jxnblk.com/styled-system/table#layout).

--- a/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
+++ b/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
@@ -18,6 +18,11 @@ exports[`<NakedButton /> renders correctly 1`] = `
 }
 
 <Clean.button
+  blacklist={
+    Array [
+      "verticalAlign",
+    ]
+  }
   className="c0"
   type="button"
 >

--- a/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
+++ b/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
@@ -15,7 +15,6 @@ exports[`<NakedButton /> renders correctly 1`] = `
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  vertical-align: middle;
 }
 
 <Clean.button

--- a/yarn.lock
+++ b/yarn.lock
@@ -8809,9 +8809,9 @@ styled-components@^3.1.5:
   dependencies:
     prop-types "^15.6.0"
 
-styled-system@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.3.2.tgz#b5dbc7d197b41dd06b80b16e17b52503363a5aac"
+styled-system@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.3.5.tgz#608ad815e2f451739f2be2b44041f3890bc9c0cd"
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
So, this was a mistake. Added `verticalAlign` prop instead of setting it to `middle` always.