### PR TITLE
fix: in calendar use width instead of flex-basis 

### DIFF
--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -6,7 +6,8 @@ import { css } from 'styled-components';
 import { Flex, NakedButton } from '../../../';
 
 const Wrapper = Flex.extend`
-  flex: 1 1 calc(100% / 7);
+  flex: 1 1 auto;
+  width: calc(100% / 7);
   justify-content: center;
   margin: 0 -1px -1px 0;
   border: ${themeGet('borders.1')} ${themeGet('colors.grey.3')};

--- a/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -147,9 +147,10 @@ exports[`<CalendarEmptyDay /> renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1 1 calc(100% / 7);
-  -ms-flex: 1 1 calc(100% / 7);
-  flex: 1 1 calc(100% / 7);
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: calc(100% / 7);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;


### PR DESCRIPTION
**What**
Fixes issue in IE where calendar days had no width. 

**Fix**
Using `width` instead of `flex-basis` made it display perfectly.