### PR TITLE
refactor: update popover styles

### DIFF
--- a/packages/components/src/Box/Box.js
+++ b/packages/components/src/Box/Box.js
@@ -17,6 +17,7 @@ import {
   flexBasis,
   flex,
   position,
+  zIndex,
 } from 'styled-system';
 
 const Box = styled(tag)`
@@ -36,6 +37,7 @@ const Box = styled(tag)`
   ${flexBasis}
   ${flex}
   ${position}
+  ${zIndex}
 `;
 
 Box.propTypes = {

--- a/packages/components/src/Box/README.md
+++ b/packages/components/src/Box/README.md
@@ -34,5 +34,7 @@ This component can be customized with [styled-system](https://github.com/jxnblk/
 `borderRadius`,
 `borders`,
 `borderColor`,
-`flexBasis` &
-`flex` [functions](https://github.com/jxnblk/styled-system#table-of-style-props)
+`flexBasis`,
+`flex`,
+`position` &
+`zIndex` [functions](https://github.com/jxnblk/styled-system#table-of-style-props)

--- a/packages/components/src/Popover/Popover.js
+++ b/packages/components/src/Popover/Popover.js
@@ -12,6 +12,7 @@ import { Box } from '../';
 const ContentWrapper = Box.extend`
   margin: ${rem('12px')};
   background: ${themeGet('colors.grey.3')};
+  border: ${themeGet('borders.2')} ${themeGet('colors.grey.2')};
   z-index: 1;
 `;
 
@@ -40,6 +41,28 @@ const Triangle = Box.extend`
    ${props => props.placement === 'left' && css`
     border-left-color: ${themeGet('colors.grey.3')};
     left: 100%;
+  `};
+`;
+
+const TriangleShadow = Triangle.extend`
+ ${props => props.placement === 'top' && css`
+    border-top-color: ${themeGet('colors.grey.2')};
+    margin-top: ${rem('2px')};
+  `};
+
+  ${props => props.placement === 'right' && css`
+    border-right-color: ${themeGet('colors.grey.2')};
+    margin-right: ${rem('2px')};
+  `};
+
+  ${props => props.placement === 'bottom' && css`
+    border-bottom-color: ${themeGet('colors.grey.2')};
+    margin-bottom: ${rem('2px')};
+  `};
+
+   ${props => props.placement === 'left' && css`
+    border-left-color: ${themeGet('colors.grey.2')};
+    margin-left: ${rem('2px')};
   `};
 `;
 
@@ -84,7 +107,6 @@ class Base extends Component {
               ref, style, placement, arrowProps,
             }) => (
               <ContentWrapper
-                boxShadow="heavy"
                 aria-hidden="true"
                 innerRef={ref}
                 style={style}
@@ -92,6 +114,12 @@ class Base extends Component {
                 className="ignore-react-onclickoutside"
               >
                 {content}
+
+                <TriangleShadow
+                  innerRef={arrowProps.ref}
+                  style={arrowProps.style}
+                  placement={placement}
+                />
                 <Triangle
                   innerRef={arrowProps.ref}
                   style={arrowProps.style}

--- a/packages/components/src/Popover/Popover.js
+++ b/packages/components/src/Popover/Popover.js
@@ -13,7 +13,6 @@ const ContentWrapper = Box.extend`
   margin: ${rem('12px')};
   background: ${themeGet('colors.grey.3')};
   border: ${themeGet('borders.2')} ${themeGet('colors.grey.2')};
-  z-index: 1;
 `;
 
 const Triangle = Box.extend`
@@ -84,7 +83,8 @@ class Base extends Component {
   }
 
   render() {
-    const childrenArray = React.Children.toArray(this.props.children);
+    const { children, zIndex } = this.props;
+    const childrenArray = React.Children.toArray(children);
     const [control, content] = partition(childrenArray, child => child.type.displayName === 'Popover.control');
 
     return (
@@ -112,6 +112,7 @@ class Base extends Component {
                 style={style}
                 placement={placement}
                 className="ignore-react-onclickoutside"
+                zIndex={zIndex}
               >
                 {content}
 
@@ -134,8 +135,13 @@ class Base extends Component {
   }
 }
 
+Base.defaultProps = {
+  zIndex: 1,
+};
+
 Base.propTypes = {
   children: PropTypes.node.isRequired,
+  zIndex: PropTypes.number,
 };
 
 const Popover = onClickOutside(Base);

--- a/packages/components/src/Popover/Popover.js
+++ b/packages/components/src/Popover/Popover.js
@@ -43,7 +43,7 @@ const Triangle = Box.extend`
   `};
 `;
 
-const TriangleShadow = Triangle.extend`
+const TriangleBorder = Triangle.extend`
  ${props => props.placement === 'top' && css`
     border-top-color: ${themeGet('colors.grey.2')};
     margin-top: ${rem('2px')};
@@ -116,7 +116,7 @@ class Base extends Component {
               >
                 {content}
 
-                <TriangleShadow
+                <TriangleBorder
                   innerRef={arrowProps.ref}
                   style={arrowProps.style}
                   placement={placement}

--- a/packages/components/src/Popover/Popover.story.js
+++ b/packages/components/src/Popover/Popover.story.js
@@ -10,7 +10,7 @@ import { Button } from '..';
 storiesOf('Components|Popover', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Popover>
+    <Popover zIndex={20}>
       <Popover.control>
         {({ openPopover, closePopover }) => (
           <Button primary onClick={openPopover} onKeyDown={closePopover}>Open popover</Button>

--- a/packages/components/src/Popover/README.md
+++ b/packages/components/src/Popover/README.md
@@ -28,6 +28,8 @@ export default (
 
 ## Properties
 
-| Name       | Description                           | Type   | Default | Required? |
-|------------|---------------------------------------|--------|---------|-----------|
-| `children` | Content and Popover.control to render | `node` | -       | ✔︎         |
+| Name       | Description                           | Type     | Default | Required? |
+|------------|---------------------------------------|----------|---------|-----------|
+| `children` | Content and Popover.control to render | `node`   | -       | ✔︎         |
+| `zIndex`   | Content zIndex                        | `number` | 1       | -         |
+

--- a/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
@@ -155,9 +155,16 @@ exports[`<Popover /> when popover is closed renders correctly 1`] = `
 
 exports[`<Popover /> when popover is open renders correctly 1`] = `
 .c0 {
-  box-shadow: heavy;
   margin: 0.75rem;
   z-index: 1;
+}
+
+.c2 {
+  height: 0;
+  width: 0;
+  border: solid transparent;
+  border-width: 0.75rem;
+  position: absolute;
 }
 
 .c1 {
@@ -333,7 +340,6 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
           >
             <Box
               aria-hidden="true"
-              boxShadow="heavy"
               className="ignore-react-onclickoutside"
               innerRef={[Function]}
               style={
@@ -440,7 +446,6 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
                     "borderWidth",
                   ]
                 }
-                boxShadow="heavy"
                 className="ignore-react-onclickoutside c0"
                 innerRef={[Function]}
                 is="div"
@@ -576,6 +581,114 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
                     >
                       <div
                         className="c1"
+                        style={Object {}}
+                      />
+                    </Clean.div>
+                  </Box>
+                  <Box
+                    innerRef={[Function]}
+                    style={Object {}}
+                  >
+                    <Clean.div
+                      blacklist={
+                        Array [
+                          "m",
+                          "mt",
+                          "mr",
+                          "mb",
+                          "ml",
+                          "mx",
+                          "my",
+                          "p",
+                          "pt",
+                          "pr",
+                          "pb",
+                          "pl",
+                          "px",
+                          "py",
+                          "width",
+                          "w",
+                          "fontSize",
+                          "f",
+                          "color",
+                          "bg",
+                          "fontFamily",
+                          "font",
+                          "textAlign",
+                          "align",
+                          "lineHeight",
+                          "fontWeight",
+                          "letterSpacing",
+                          "display",
+                          "maxWidth",
+                          "minWidth",
+                          "height",
+                          "maxHeight",
+                          "minHeight",
+                          "size",
+                          "ratio",
+                          "alignItems",
+                          "alignContent",
+                          "justifyContent",
+                          "justify",
+                          "flexWrap",
+                          "wrap",
+                          "flexBasis",
+                          "flexDirection",
+                          "flex",
+                          "justifySelf",
+                          "alignSelf",
+                          "order",
+                          "gridGap",
+                          "gridColumnGap",
+                          "gridRowGap",
+                          "gridColumn",
+                          "gridRow",
+                          "gridAutoFlow",
+                          "gridAutoColumns",
+                          "gridAutoRows",
+                          "gridTemplateColumns",
+                          "gridTemplateRows",
+                          "border",
+                          "borderTop",
+                          "borderRight",
+                          "borderBottom",
+                          "borderLeft",
+                          "borderColor",
+                          "borderRadius",
+                          "boxShadow",
+                          "background",
+                          "backgroundImage",
+                          "bgImage",
+                          "backgroundSize",
+                          "bgSize",
+                          "backgroundPosition",
+                          "bgPosition",
+                          "backgroundRepeat",
+                          "bgRepeat",
+                          "position",
+                          "zIndex",
+                          "top",
+                          "right",
+                          "bottom",
+                          "left",
+                          "hover",
+                          "focus",
+                          "active",
+                          "disabledStyle",
+                          "textStyle",
+                          "colors",
+                          "buttonStyle",
+                          "borderWidth",
+                        ]
+                      }
+                      className="c2"
+                      innerRef={[Function]}
+                      is="div"
+                      style={Object {}}
+                    >
+                      <div
+                        className="c2"
                         style={Object {}}
                       />
                     </Clean.div>

--- a/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
@@ -26,6 +26,7 @@ exports[`<Popover /> when popover is closed renders correctly 1`] = `
       outsideClickIgnoreClass="ignore-react-onclickoutside"
       preventDefault={false}
       stopPropagation={false}
+      zIndex={1}
     >
       <Manager>
         <Reference>
@@ -155,8 +156,8 @@ exports[`<Popover /> when popover is closed renders correctly 1`] = `
 
 exports[`<Popover /> when popover is open renders correctly 1`] = `
 .c0 {
-  margin: 0.75rem;
   z-index: 1;
+  margin: 0.75rem;
 }
 
 .c2 {
@@ -200,6 +201,7 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
       outsideClickIgnoreClass="ignore-react-onclickoutside"
       preventDefault={false}
       stopPropagation={false}
+      zIndex={1}
     >
       <Manager>
         <Reference>
@@ -351,6 +353,7 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
                   "top": 0,
                 }
               }
+              zIndex={1}
             >
               <Clean.div
                 aria-hidden="true"
@@ -458,6 +461,7 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
                     "top": 0,
                   }
                 }
+                zIndex={1}
               >
                 <div
                   aria-hidden="true"


### PR DESCRIPTION
**What**
Update two issues we had when using `Popover`.

1. Add a grey outline to `Popover`. We didn't have enough contrast and its what Qantas uses.
2. Add ability to change `z-index`. 