### PR TITLE
refactor: update star rating props

### DIFF
--- a/packages/components/src/StarRating/README.md
+++ b/packages/components/src/StarRating/README.md
@@ -13,15 +13,13 @@ $ yarn add @roo-ui/components
 ```js
 import { StarRating } from '@roo-ui/components';
 
-export default (
-  <StarRating />
-);
+export default <StarRating />;
 ```
 
 ## Properties
 
-|   Name       |       Description       |   Type   | Default | Required? |
-| :----------- | :---------------------- | :------- | :------ | :-------- |
-| `rating`     | from 1 to 5 | `string`  | -        | true    | ✔︎         |
-| `ratingType` | AAA or SELF_RATED       | `string` | -       | ✔︎         |
-| `size`       | size of the icon        | `string` | -       | ✔︎         |
+| Name         | Description              | Type                  | Default | Required? |
+| :----------- | :----------------------- | :-------------------- | :------ | :-------- |
+| `rating`     | from 0.5 to 5            | `string` or `number`  | -       | ✔︎        |
+| `ratingType` | type of rating to render | `AAA` or 'SELF_RATED' | -       | ✔︎        |
+| `size`       | size of the icons        | `string` or `number`  | -       | ✔︎        |

--- a/packages/components/src/StarRating/README.md
+++ b/packages/components/src/StarRating/README.md
@@ -21,5 +21,5 @@ export default <StarRating />;
 | Name         | Description              | Type                  | Default | Required? |
 | :----------- | :----------------------- | :-------------------- | :------ | :-------- |
 | `rating`     | from 0.5 to 5            | `string` or `number`  | -       | ✔︎        |
-| `ratingType` | type of rating to render | `AAA` or 'SELF_RATED' | -       | ✔︎        |
+| `ratingType` | type of rating to render | `AAA` or `SELF_RATED` | -       | ✔︎        |
 | `size`       | size of the icons        | `string` or `number`  | -       | ✔︎        |

--- a/packages/components/src/StarRating/StarRating.js
+++ b/packages/components/src/StarRating/StarRating.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Flex, Icon } from '..';
 
 const iconType = (rating, index, ratingType) => {
-  const ratingTypeIcon = (ratingType === 'AAA') ? 'star' : 'circle';
+  const ratingTypeIcon = ratingType === 'AAA' ? 'star' : 'circle';
 
   if (index < rating - 0.5) return `${ratingTypeIcon}`;
   if (index < rating) return `${ratingTypeIcon}Half`;
@@ -36,10 +36,12 @@ const StarRating = ({ ratingType, rating, size }) => (
   </Flex>
 );
 
+const stringOrNumber = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+
 StarRating.propTypes = {
-  rating: PropTypes.string.isRequired,
-  ratingType: PropTypes.string.isRequired,
-  size: PropTypes.string.isRequired,
+  rating: stringOrNumber.isRequired,
+  ratingType: PropTypes.oneOf(['AAA', 'SELF_RATED']).isRequired,
+  size: stringOrNumber.isRequired,
 };
 
 export default StarRating;


### PR DESCRIPTION
- Allow number or string for rating and icon size
- Restrict rating type to `'AAA'` or `'SELF_RATED'`