### PR TITLE
feat: add flexFlow shorthand css Property

### DIFF
--- a/packages/components/src/Flex/Flex.js
+++ b/packages/components/src/Flex/Flex.js
@@ -4,8 +4,14 @@ import {
   justifyContent,
   flexWrap,
   flexDirection,
+  style,
 } from 'styled-system';
 import Box from '../Box';
+
+const flexFlow = style({
+  prop: 'flexFlow',
+  cssProperty: 'flexFlow',
+});
 
 const Flex = Box.extend`
   display: flex;
@@ -14,6 +20,7 @@ const Flex = Box.extend`
   ${justifyContent}
   ${flexWrap}
   ${flexDirection}
+  ${flexFlow}
 `;
 
 Flex.propTypes = {
@@ -23,6 +30,7 @@ Flex.propTypes = {
   ...justifyContent.propTypes,
   ...flexWrap.propTypes,
   ...flexDirection.propTypes,
+  ...flexFlow.propTypes,
 };
 
 export default Flex;

--- a/packages/components/src/Flex/README.md
+++ b/packages/components/src/Flex/README.md
@@ -23,5 +23,5 @@ export default (
 
 ## Customization
 
-This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for `alignContent`, `alignItems`, `justifyContent`, `flexWrap` & `flexDirection` [functions](https://github.com/jxnblk/styled-system#table-of-style-props)
+This component can be customized with [styled-system](https://github.com/jxnblk/styled-system) by passing props for `alignContent`, `alignItems`, `justifyContent`, `flexWrap`, `flexFlow` & `flexDirection` [functions](https://github.com/jxnblk/styled-system#table-of-style-props)
 as well as props supported by [`<Box />`](../Box/README.md)


### PR DESCRIPTION
### What

`flexFlow` is shorthand for `flexDirection` and `flexWrap` 

It's a nice to have but it is nice!

https://developer.mozilla.org/en-US/docs/Web/CSS/flex-flow

![Alt Text](https://media.giphy.com/media/vFKqnCdLPNOKc/giphy.gif)