### PR TITLE
feat(greys): converts greys array to an object and introduces a new grey

### DIFF
--- a/packages/assets/story.js
+++ b/packages/assets/story.js
@@ -11,7 +11,7 @@ import README from './README.md';
 storiesOf('Foundations|Assets', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Box p={6} bg="grey.3">
+    <Box p={6} bg="greys.porcelain">
       <img
         src={select('Assets', invert(assets), Object.values(assets)[0])}
         height="100"

--- a/packages/components/src/Alert/Alert.js
+++ b/packages/components/src/Alert/Alert.js
@@ -59,7 +59,7 @@ Base.defaultProps = {
 const Alert = Box.withComponent(Base);
 Alert.defaultProps = {
   ...Box.defaultProps,
-  bg: 'grey.3',
+  bg: 'greys.porcelain',
   mb: 3,
 };
 
@@ -70,7 +70,7 @@ Alert.info.defaultProps = {
   bg: 'ui.infoBackground',
   icon: {
     name: 'info',
-    color: 'grey.0',
+    color: 'greys.charcoal',
   },
 };
 

--- a/packages/components/src/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__snapshots__/Alert.test.js.snap
@@ -89,7 +89,7 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
         pr={3}
       >
         <Icon
-          color="grey.0"
+          color="greys.charcoal"
           name="info"
         />
       </Box>
@@ -211,7 +211,7 @@ exports[`<Alert /> contained renders correctly 1`] = `
 }
 
 <Cleaned
-  bg="grey.3"
+  bg="greys.porcelain"
   className="c0"
   mb={3}
 >
@@ -292,7 +292,7 @@ exports[`<Alert /> renders correctly 1`] = `
 }
 
 <Cleaned
-  bg="grey.3"
+  bg="greys.porcelain"
   className="c0"
   mb={3}
 >

--- a/packages/components/src/Autocomplete/Autocomplete.js
+++ b/packages/components/src/Autocomplete/Autocomplete.js
@@ -17,8 +17,8 @@ const Menu = Box.extend`
   position: absolute;
   width: 100%;
   margin-top: -${themeGet('space.3')};
-  border-left: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
-  border-right: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
+  border-left: ${themeGet('borders.1')} ${themeGet('colors.greys.alto')};
+  border-right: ${themeGet('borders.1')} ${themeGet('colors.greys.alto')};
   z-index: 2;
   max-height: ${rem('230px')};
   overflow-y: scroll;
@@ -27,8 +27,8 @@ const Menu = Box.extend`
 Menu.displayName = 'Menu';
 
 const MenuItem = Box.extend`
-  background-color: ${themeGet('colors.grey.3')};
-  border-bottom: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
+  background-color: ${themeGet('colors.greys.porcelain')};
+  border-bottom: ${themeGet('borders.1')} ${themeGet('colors.greys.alto')};
   border-left: ${themeGet('borders.1')} transparent;
   padding: ${themeGet('space.3')} ${themeGet('space.4')};
 

--- a/packages/components/src/BlockLink/BlockLink.story.js
+++ b/packages/components/src/BlockLink/BlockLink.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|BlockLink', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <BlockLink href="https://www.qantas.com" target="_blank">
-      <Box p={3} bg="grey.3">
+      <Box p={3} bg="greys.porcelain">
         Hello world
       </Box>
     </BlockLink>

--- a/packages/components/src/Box/Box.story.js
+++ b/packages/components/src/Box/Box.story.js
@@ -8,7 +8,7 @@ import README from './README.md';
 storiesOf('Components|Box', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Box p={3} bg="grey.3">
+    <Box p={3} bg="greys.porcelain">
       Hello world
     </Box>
   ));

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -10,7 +10,7 @@ const Wrapper = Flex.extend`
   width: calc(100% / 7);
   justify-content: center;
   margin: 0 -1px -1px 0;
-  border: ${themeGet('borders.1')} ${themeGet('colors.grey.3')};
+  border: ${themeGet('borders.1')} ${themeGet('colors.greys.porcelain')};
 
   &:after {
     content: '';
@@ -20,14 +20,14 @@ const Wrapper = Flex.extend`
 `;
 
 const Button = NakedButton.extend`
-  color: ${themeGet('colors.grey.0')};
+  color: ${themeGet('colors.greys.charcoal')};
   padding: 0;
   width: 100%;
   border: ${themeGet('borders.2')} transparent;
 
   &:disabled {
     cursor: not-allowed;
-    background-color: ${themeGet('colors.grey.2')};
+    background-color: ${themeGet('colors.greys.alto')};
   }
 
   ${props => props.selectable &&

--- a/packages/components/src/Calendar/components/CalendarNav/CalendarNav.js
+++ b/packages/components/src/Calendar/components/CalendarNav/CalendarNav.js
@@ -14,7 +14,7 @@ const Wrapper = Flex.extend`
 const Button = NakedButton.extend`
   border-radius: ${themeGet('radii.rounded')};
   background: ${themeGet('colors.white')};
-  color: ${themeGet('colors.grey.1')};
+  color: ${themeGet('colors.greys.steel')};
   box-shadow: ${themeGet('shadows.default')};
 
   &:hover,
@@ -26,7 +26,7 @@ const Button = NakedButton.extend`
   &:disabled {
     cursor: not-allowed;
     box-shadow: none;
-    color: ${themeGet('colors.grey.2')};
+    color: ${themeGet('colors.greys.alto')};
   }
 `;
 

--- a/packages/components/src/Calendar/components/CalendarWeekdays/CalendarWeekdays.js
+++ b/packages/components/src/Calendar/components/CalendarWeekdays/CalendarWeekdays.js
@@ -8,7 +8,7 @@ export const CalendarWeekdays = Flex.extend`
   padding-bottom: ${themeGet('space.2')};
   margin-top: ${themeGet('space.5')};
   margin-bottom: ${themeGet('space.3')};
-  border-bottom: ${themeGet('borders.1')} ${themeGet('colors.grey.2')};
+  border-bottom: ${themeGet('borders.1')} ${themeGet('colors.greys.alto')};
 `;
 
 export const CalendarWeekday = ({ children, ...rest }) => (
@@ -20,4 +20,3 @@ export const CalendarWeekday = ({ children, ...rest }) => (
 CalendarWeekday.propTypes = {
   children: PropTypes.node.isRequired,
 };
-

--- a/packages/components/src/Card/Card.story.js
+++ b/packages/components/src/Card/Card.story.js
@@ -9,7 +9,7 @@ import README from './README.md';
 storiesOf('Components|Card', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
-    <Box p={6} bg="grey.3">
+    <Box p={6} bg="greys.porcelain">
       <Card>
         Hello world
       </Card>

--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -39,7 +39,7 @@ const CheckboxBorder = styled(tag.div)`
   width: ${rem('20px')};
   background-color: ${themeGet('colors.white')};
   border: ${themeGet('borders.2')};
-  border-color: ${themeGet('colors.grey.2')};
+  border-color: ${themeGet('colors.greys.alto')};
   border-radius: ${themeGet('radii.default')};
 
   input:checked + &,
@@ -50,15 +50,15 @@ const CheckboxBorder = styled(tag.div)`
   }
 
   input:disabled + & {
-    background-color: ${themeGet('colors.grey.2')};
-    border-color: ${themeGet('colors.grey.2')};
+    background-color: ${themeGet('colors.greys.alto')};
+    border-color: ${themeGet('colors.greys.alto')};
   }
 `;
 
 const CheckboxIcon = Icon.extend`
   position: absolute;
   display: none;
-  color: ${themeGet('colors.grey.0')};
+  color: ${themeGet('colors.greys.charcoal')};
   padding: ${themeGet('space.1')};
   top: 0;
   left: -${rem('2px')};

--- a/packages/components/src/Container/Container.story.js
+++ b/packages/components/src/Container/Container.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|Container', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <Container>
-      <Box p={3} bg="grey.3">
+      <Box p={3} bg="greys.porcelain">
         Hello world
       </Box>
     </Container>

--- a/packages/components/src/Dropdown/Dropdown.js
+++ b/packages/components/src/Dropdown/Dropdown.js
@@ -87,14 +87,14 @@ Dropdown.propTypes = {
 
 Dropdown.item = NakedButton.extend`
   padding: ${themeGet('space.2')} ${themeGet('space.8')};
-  color: ${themeGet('colors.grey.1')};
+  color: ${themeGet('colors.greys.steel')};
   width: 100%;
   display: block;
   text-align: left;
   text-decoration: none;
 
   ${props => props.highlighted && css`
-    color: ${themeGet('colors.grey.0')};
+    color: ${themeGet('colors.greys.charcoal')};
     font-weight: ${themeGet('fontWeights.bold')};
   `}
 `;

--- a/packages/components/src/ExternalLink/ExternalLink.js
+++ b/packages/components/src/ExternalLink/ExternalLink.js
@@ -2,7 +2,7 @@ import { themeGet } from 'styled-system';
 import { Link } from '..';
 
 const ExternalLink = Link.extend`
-  color: ${themeGet('colors.grey.0')};
+  color: ${themeGet('colors.greys.charcoal')};
 `;
 
 ExternalLink.defaultProps = {

--- a/packages/components/src/Flex/Flex.story.js
+++ b/packages/components/src/Flex/Flex.story.js
@@ -10,7 +10,7 @@ storiesOf('Components|Flex', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <Flex>
-      <Box width={1 / 2} p={3} m={3} bg="grey.3">Flex</Box>
-      <Box width={1 / 2} p={3} m={3} bg="grey.3">Box</Box>
+      <Box width={1 / 2} p={3} m={3} bg="greys.porcelain">Flex</Box>
+      <Box width={1 / 2} p={3} m={3} bg="greys.porcelain">Box</Box>
     </Flex>
   ));

--- a/packages/components/src/Icon/Icon.story.js
+++ b/packages/components/src/Icon/Icon.story.js
@@ -31,8 +31,8 @@ const renderIcons = group => () => (
   <Grid>
     {groupedPaths[group].map(({ name }) => (
       <Box p={4}>
-        <Icon color="grey.1" size={48} name={name} />
-        <Caption title={name} fontSize="xs" color="grey.1">{name}</Caption>
+        <Icon color="greys.steel" size={48} name={name} />
+        <Caption title={name} fontSize="xs" color="greys.steel">{name}</Caption>
       </Box>
     ))}
   </Grid>
@@ -58,4 +58,3 @@ storiesOf('Components|Icon', module)
   .add('social', renderIcons('social'))
   .add('toggle', renderIcons('toggle'))
   .add('qantas', renderIcons('qantas'));
-

--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -11,10 +11,10 @@ const Input = styled(tag)`
   padding: ${themeGet('space.3')} ${themeGet('space.4')};
   font-size: ${themeGet('fontSizes.base')};
   line-height: ${themeGet('lineHeights.normal')};
-  color: ${themeGet('colors.grey.0')};
+  color: ${themeGet('colors.greys.charcoal')};
   background-color: ${themeGet('colors.white')};
   border: ${themeGet('borders.2')};
-  border-color: ${themeGet('colors.grey.2')};
+  border-color: ${themeGet('colors.greys.alto')};
   outline: 0;
   transition: border-color ${themeGet('transitions.default')};
   appearance: none;
@@ -30,7 +30,7 @@ const Input = styled(tag)`
   }
 
   ::placeholder {
-    color: ${themeGet('colors.grey.1')};
+    color: ${themeGet('colors.greys.steel')};
   }
 
   ::-ms-clear {
@@ -40,7 +40,7 @@ const Input = styled(tag)`
   ${props => props.underline && css`
     border: none;
     border-bottom: ${themeGet('borders.2')};
-    border-color: ${themeGet('colors.grey.2')};
+    border-color: ${themeGet('colors.greys.alto')};
   `}
 
   ${props => props.error && css`

--- a/packages/components/src/LoadingIndicator/LoadingIndicator.js
+++ b/packages/components/src/LoadingIndicator/LoadingIndicator.js
@@ -65,7 +65,7 @@ LoadingIndicator.propTypes = {
 };
 
 LoadingIndicator.defaultProps = {
-  color: 'grey.1',
+  color: 'greys.steel',
   size: 18,
   delay: 0,
 };

--- a/packages/components/src/LoadingIndicator/README.md
+++ b/packages/components/src/LoadingIndicator/README.md
@@ -20,8 +20,8 @@ export default (
 
 ## Properties
 
-| Name    | Description                                                    | Type                 | Default | Required? |
-|:--------|:---------------------------------------------------------------|:---------------------|:--------|:----------|
-| `size`  | width & height of individual bouncer                           | `string` or `number` | 18px    | false     |
-| `delay` | delay visibility. Number values passed are in ms (500 = 500ms) | `string` or `number` | 0       | false     |
-| `color` | colour of individual bouncer                                   | `string`             | grey[1] | false     |
+| Name    | Description                                                    | Type                 | Default     | Required? |
+|:--------|:---------------------------------------------------------------|:---------------------|:------------|:----------|
+| `size`  | width & height of individual bouncer                           | `string` or `number` | 18px        | false     |
+| `delay` | delay visibility. Number values passed are in ms (500 = 500ms) | `string` or `number` | 0           | false     |
+| `color` | colour of individual bouncer                                   | `string`             | greys.steel | false     |

--- a/packages/components/src/LoadingIndicator/__snapshots__/LoadingIndicator.test.js.snap
+++ b/packages/components/src/LoadingIndicator/__snapshots__/LoadingIndicator.test.js.snap
@@ -25,15 +25,15 @@ exports[`<LoadingIndicator /> matches snapshot 1`] = `
   width={72}
 >
   <LoadingIndicator__Bouncer
-    bg="grey.1"
+    bg="greys.steel"
     size={18}
   />
   <LoadingIndicator__Bouncer
-    bg="grey.1"
+    bg="greys.steel"
     size={18}
   />
   <LoadingIndicator__Bouncer
-    bg="grey.1"
+    bg="greys.steel"
     size={18}
   />
 </Box>

--- a/packages/components/src/PasswordInput/PasswordInput.js
+++ b/packages/components/src/PasswordInput/PasswordInput.js
@@ -20,11 +20,11 @@ const Toggle = styled(NakedButton)`
   top: 0;
   left: calc(100% - ${rem('80px')});
   font-size: ${themeGet('fontSizes.sm')};
-  color: ${themeGet('colors.grey.1')};
+  color: ${themeGet('colors.greys.steel')};
   text-decoration: underline;
 
   &:focus {
-    color: ${themeGet('colors.grey.0')};
+    color: ${themeGet('colors.greys.charcoal')};
     outline: none;
   }
 `;

--- a/packages/components/src/Popover/Popover.js
+++ b/packages/components/src/Popover/Popover.js
@@ -11,8 +11,8 @@ import { Box } from '../';
 
 const ContentWrapper = Box.extend`
   margin: ${rem('12px')};
-  background: ${themeGet('colors.grey.3')};
-  border: ${themeGet('borders.2')} ${themeGet('colors.grey.2')};
+  background: ${themeGet('colors.greys.porcelain')};
+  border: ${themeGet('borders.2')} ${themeGet('colors.greys.alto')};
 `;
 
 const Triangle = Box.extend`
@@ -23,44 +23,44 @@ const Triangle = Box.extend`
   position: absolute;
 
   ${props => props.placement === 'top' && css`
-    border-top-color: ${themeGet('colors.grey.3')};
+    border-top-color: ${themeGet('colors.greys.porcelain')};
     top: 100%;
   `};
 
   ${props => props.placement === 'right' && css`
-    border-right-color: ${themeGet('colors.grey.3')};
+    border-right-color: ${themeGet('colors.greys.porcelain')};
     right: 100%;
   `};
 
   ${props => props.placement === 'bottom' && css`
-    border-bottom-color: ${themeGet('colors.grey.3')};
+    border-bottom-color: ${themeGet('colors.greys.porcelain')};
     bottom: 100%;
   `};
 
    ${props => props.placement === 'left' && css`
-    border-left-color: ${themeGet('colors.grey.3')};
+    border-left-color: ${themeGet('colors.greys.porcelain')};
     left: 100%;
   `};
 `;
 
 const TriangleBorder = Triangle.extend`
  ${props => props.placement === 'top' && css`
-    border-top-color: ${themeGet('colors.grey.2')};
+    border-top-color: ${themeGet('colors.greys.alto')};
     margin-top: ${rem('2px')};
   `};
 
   ${props => props.placement === 'right' && css`
-    border-right-color: ${themeGet('colors.grey.2')};
+    border-right-color: ${themeGet('colors.greys.alto')};
     margin-right: ${rem('2px')};
   `};
 
   ${props => props.placement === 'bottom' && css`
-    border-bottom-color: ${themeGet('colors.grey.2')};
+    border-bottom-color: ${themeGet('colors.greys.alto')};
     margin-bottom: ${rem('2px')};
   `};
 
    ${props => props.placement === 'left' && css`
-    border-left-color: ${themeGet('colors.grey.2')};
+    border-left-color: ${themeGet('colors.greys.alto')};
     margin-left: ${rem('2px')};
   `};
 `;

--- a/packages/components/src/Radio/Radio.js
+++ b/packages/components/src/Radio/Radio.js
@@ -37,7 +37,7 @@ const RadioIcon = styled(tag.div)`
   width: ${rem('20px')};
   background-color: ${themeGet('colors.white')};
   border: ${themeGet('borders.2')};
-  border-color: ${themeGet('colors.grey.2')};
+  border-color: ${themeGet('colors.greys.alto')};
   border-radius: 50%;
   z-index: 1;
 
@@ -58,13 +58,13 @@ const RadioIcon = styled(tag.div)`
       height: ${themeGet('space.2')};
       width: ${themeGet('space.2')};
       border-radius: 50%;
-      background-color: ${themeGet('colors.grey.0')};
+      background-color: ${themeGet('colors.greys.charcoal')};
     }
   }
 
   input:disabled + & {
-    background-color: ${themeGet('colors.grey.2')};
-    border-color: ${themeGet('colors.grey.2')};
+    background-color: ${themeGet('colors.greys.alto')};
+    border-color: ${themeGet('colors.greys.alto')};
   }
 `;
 

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -18,12 +18,14 @@ const colors = {
     success: '#35A509',
     successBackground: '#DEF2DE',
   },
-  grey: [
-    '#323232',
-    '#666666',
-    '#DADADA',
-    '#F4F5F6',
-  ],
+  greys: {
+    charcoal: '#323232',
+    steel: '#666666',
+    alto: '#DADADA',
+    porcelain: '#F4F5F6',
+    dusty: '#999999',
+  },
+
   white: '#FFFFFF',
   text: '#323232',
   starRating: '#FBCB3B',
@@ -70,7 +72,7 @@ const textStyles = {
   label: {
     fontSize: fontSizes.sm,
     fontWeight: fontWeights.bold,
-    color: colors.grey[0],
+    color: colors.greys.charcoal,
   },
   h1: {
     fontSize: fontSizes['3xl'],
@@ -175,7 +177,7 @@ const transitions = {
 const buttons = {
   default: {
     color: 'white',
-    backgroundColor: colors.grey[0],
+    backgroundColor: colors.greys.charcoal,
   },
   primary: {
     color: 'white',


### PR DESCRIPTION
### What

With the need for a new grey comes the need to move from an array to an object.

### What changed

For the grey colors in theme/qantas.js:

Key -> from *grey* to **greys**
Value -> from an *array* to an **object**.

### What to do
Replace: 
`colors.grey.0` with `colors.greys.charcoal`
`colors.grey.1` with `colors.greys.steel`
`colors.grey.2` with `colors.greys.alto`
`colors.grey.3` with `colors.greys.porcelain`

NEW!
`colors.greys.dusty`  (`#999999`)