### PR TITLE
fix: calendar tweaks

### DIFF
--- a/packages/components/src/Calendar/Calendar.story.js
+++ b/packages/components/src/Calendar/Calendar.story.js
@@ -18,20 +18,7 @@ storiesOf('Components|Calendar', module)
       selected={new Date()}
       onDateSelected={console.log} // eslint-disable-line no-console
       stacked={boolean('Stacked', false)}
-      selected={[
-        addDays(new Date(), 1),
-        addDays(new Date(), 2),
-        addDays(new Date(), 3),
-        addDays(new Date(), 4),
-        addDays(new Date(), 5),
-        addDays(new Date(), 6),
-        addDays(new Date(), 7),
-        addDays(new Date(), 8),
-        addDays(new Date(), 9),
-        addDays(new Date(), 10),
-        addDays(new Date(), 11),
-
-      ]}
+      disabledDates={[addDays(new Date(), 1), addDays(new Date(), 2), addDays(new Date(), 4)]}
       interactiveDisabledDates
     />
   ));

--- a/packages/components/src/Calendar/Calendar.story.js
+++ b/packages/components/src/Calendar/Calendar.story.js
@@ -18,7 +18,20 @@ storiesOf('Components|Calendar', module)
       selected={new Date()}
       onDateSelected={console.log} // eslint-disable-line no-console
       stacked={boolean('Stacked', false)}
-      disabledDates={[addDays(new Date(), 1), addDays(new Date(), 2), addDays(new Date(), 4)]}
+      selected={[
+        addDays(new Date(), 1),
+        addDays(new Date(), 2),
+        addDays(new Date(), 3),
+        addDays(new Date(), 4),
+        addDays(new Date(), 5),
+        addDays(new Date(), 6),
+        addDays(new Date(), 7),
+        addDays(new Date(), 8),
+        addDays(new Date(), 9),
+        addDays(new Date(), 10),
+        addDays(new Date(), 11),
+
+      ]}
       interactiveDisabledDates
     />
   ));

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -19,6 +19,11 @@ const Wrapper = Box.extend`
     padding-bottom: 100%;
   }
 
+  &:hover {
+    border-color: ${ themeGet('colors.brand.secondary') };
+    z-index: 1;
+  }
+
   ${props =>
     props.selected &&
     css`

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -68,7 +68,7 @@ const Button = NakedButton.extend`
     `};
 
     ${props =>
-      props.selectable &&
+    props.selectable &&
       !props.selected &&
       css`
         &:hover,
@@ -116,4 +116,5 @@ export const CalendarDay = ({ children, selected, ...rest }) => (
 
 CalendarDay.propTypes = {
   children: PropTypes.node.isRequired,
+  selected: PropTypes.bool.isRequired,
 };

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -9,15 +9,22 @@ import { Flex, NakedButton, Box } from '../../../';
 const Wrapper = Box.extend`
   flex: 1 1 auto;
   width: calc(100% / 7);
-  margin: 0 -1px -1px 0;
+  margin: 0 -2px -2px 0;
   position: relative;
-  border: ${themeGet('borders.1')} ${themeGet('colors.greys.porcelain')};
+  border: ${themeGet('borders.2')} ${themeGet('colors.greys.porcelain')};
 
   &:after {
     content: "";
     display: block;
     padding-bottom: 100%;
   }
+
+  ${props =>
+    props.selected &&
+    css`
+      z-index: 1;
+      border-color: ${themeGet('colors.brand.secondary')};
+    `};
 `;
 
 const Button = NakedButton.extend`
@@ -44,11 +51,6 @@ const Button = NakedButton.extend`
     css`
       background-color: ${themeGet('colors.white')};
 
-      &:hover,
-      &:focus {
-        border-color: ${themeGet('colors.brand.secondary')};
-      }
-
       &:active {
         background-color: ${themeGet('colors.ui.infoBackground')};
       }
@@ -58,13 +60,22 @@ const Button = NakedButton.extend`
     props.selected &&
     css`
       background-color: ${themeGet('colors.ui.infoBackground')};
-      border-color: ${themeGet('colors.brand.secondary')};
 
       &:hover,
       &:focus {
         background-color: ${themeGet('colors.white')};
       }
     `};
+
+    ${props =>
+      props.selectable &&
+      !props.selected &&
+      css`
+        &:hover,
+        &:focus {
+          background-color: ${themeGet('colors.ui.infoBackground')};
+        }
+      `};
 
   ${props =>
     !props.selectable &&
@@ -87,8 +98,8 @@ Button.defaultProps = {
 
 export const CalendarDays = Flex.extend`
   flex-wrap: wrap;
-  margin-bottom: 1px;
-  margin-right: 1px;
+  margin-bottom: 2px;
+  margin-right: 2px;
 `;
 
 export const CalendarEmptyDay = Wrapper.withComponent('div').extend`
@@ -97,9 +108,9 @@ export const CalendarEmptyDay = Wrapper.withComponent('div').extend`
 
 CalendarEmptyDay.displayName = 'CalendarEmptyDay';
 
-export const CalendarDay = ({ children, ...rest }) => (
-  <Wrapper>
-    <Button {...rest}>{children}</Button>
+export const CalendarDay = ({ children, selected, ...rest }) => (
+  <Wrapper selected={selected}>
+    <Button selected={selected} {...rest}>{children}</Button>
   </Wrapper>
 );
 

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -4,26 +4,30 @@ import { themeGet } from 'styled-system';
 import { css } from 'styled-components';
 import { darken } from 'polished';
 
-import { Flex, NakedButton } from '../../../';
+import { Flex, NakedButton, Box } from '../../../';
 
-const Wrapper = Flex.extend`
+const Wrapper = Box.extend`
   flex: 1 1 auto;
   width: calc(100% / 7);
-  justify-content: center;
   margin: 0 -1px -1px 0;
+  position: relative;
   border: ${themeGet('borders.1')} ${themeGet('colors.greys.porcelain')};
 
   &:after {
-    content: '';
+    content: "";
     display: block;
     padding-bottom: 100%;
   }
 `;
 
 const Button = NakedButton.extend`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
   color: ${themeGet('colors.greys.charcoal')};
   padding: 0;
-  width: 100%;
   border: ${themeGet('borders.2')} transparent;
 
   &:focus {
@@ -35,7 +39,8 @@ const Button = NakedButton.extend`
     background-color: ${themeGet('colors.greys.alto')};
   }
 
-  ${props => props.selectable &&
+  ${props =>
+    props.selectable &&
     css`
       background-color: ${themeGet('colors.white')};
 
@@ -47,9 +52,10 @@ const Button = NakedButton.extend`
       &:active {
         background-color: ${themeGet('colors.ui.infoBackground')};
       }
-  `};
+    `};
 
-  ${props => props.selected &&
+  ${props =>
+    props.selected &&
     css`
       background-color: ${themeGet('colors.ui.infoBackground')};
       border-color: ${themeGet('colors.brand.secondary')};
@@ -58,9 +64,11 @@ const Button = NakedButton.extend`
       &:focus {
         background-color: ${themeGet('colors.white')};
       }
-  `};
+    `};
 
-  ${props => !props.selectable && !props.disabled &&
+  ${props =>
+    !props.selectable &&
+    !props.disabled &&
     css`
       background-color: ${themeGet('colors.greys.alto')};
 
@@ -68,7 +76,7 @@ const Button = NakedButton.extend`
       &:focus {
         background-color: ${darken(0.1, themeGet('colors.greys.alto')(props))};
       }
-  `};
+    `};
 `;
 
 Button.defaultProps = {
@@ -91,9 +99,7 @@ CalendarEmptyDay.displayName = 'CalendarEmptyDay';
 
 export const CalendarDay = ({ children, ...rest }) => (
   <Wrapper>
-    <Button {...rest}>
-      {children}
-    </Button>
+    <Button {...rest}>{children}</Button>
   </Wrapper>
 );
 

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -20,7 +20,7 @@ const Wrapper = Box.extend`
   }
 
   &:hover {
-    border-color: ${ themeGet('colors.brand.secondary') };
+    border-color: ${themeGet('colors.brand.secondary')};
     z-index: 1;
   }
 

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.js
@@ -62,11 +62,11 @@ const Button = NakedButton.extend`
 
   ${props => !props.selectable && !props.disabled &&
     css`
-      background-color: ${themeGet('colors.grey.2')};
+      background-color: ${themeGet('colors.greys.alto')};
 
       &:hover,
       &:focus {
-        background-color: ${darken(0.1, themeGet('colors.grey.2')(props))};
+        background-color: ${darken(0.1, themeGet('colors.greys.alto')(props))};
       }
   `};
 `;

--- a/packages/components/src/Calendar/components/CalendarDays/CalendarDays.test.js
+++ b/packages/components/src/Calendar/components/CalendarDays/CalendarDays.test.js
@@ -6,7 +6,7 @@ import { CalendarDay, CalendarEmptyDay, CalendarDays } from '.';
 
 describe('<CalendarDay />', () => {
   it('renders correctly', () => {
-    expect(shallowWithTheme(<CalendarDay>21</CalendarDay>, theme)).toMatchSnapshot();
+    expect(shallowWithTheme(<CalendarDay selected>21</CalendarDay>, theme)).toMatchSnapshot();
   });
 });
 
@@ -18,6 +18,6 @@ describe('<CalendarEmptyDay />', () => {
 
 describe('<CalendarDays />', () => {
   it('renders correctly', () => {
-    expect(shallowWithTheme(<CalendarDays>Day</CalendarDays>, theme)).toMatchSnapshot();
+    expect(shallowWithTheme(<CalendarDays selected>Day</CalendarDays>, theme)).toMatchSnapshot();
   });
 });

--- a/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CalendarDay /> renders correctly 1`] = `
-<Box>
+<Box
+  selected={true}
+>
   <NakedButton
     blacklist={
       Array [
@@ -24,6 +26,7 @@ exports[`<CalendarDay /> renders correctly 1`] = `
       ]
     }
     disabled={[Function]}
+    selected={true}
   >
     21
   </NakedButton>
@@ -39,8 +42,8 @@ exports[`<CalendarDays /> renders correctly 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-bottom: 1px;
-  margin-right: 1px;
+  margin-bottom: 2px;
+  margin-right: 2px;
 }
 
 <Clean.div
@@ -138,6 +141,7 @@ exports[`<CalendarDays /> renders correctly 1`] = `
   }
   className="c0"
   is="div"
+  selected={true}
 >
   Day
 </Clean.div>
@@ -149,9 +153,9 @@ exports[`<CalendarEmptyDay /> renders correctly 1`] = `
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   width: calc(100% / 7);
-  margin: 0 -1px -1px 0;
+  margin: 0 -2px -2px 0;
   position: relative;
-  border: 1px solid #F4F5F6;
+  border: 2px solid #F4F5F6;
   border-color: transparent;
 }
 

--- a/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -165,6 +165,11 @@ exports[`<CalendarEmptyDay /> renders correctly 1`] = `
   padding-bottom: 100%;
 }
 
+.c0:hover {
+  border-color: #8DE2E0;
+  z-index: 1;
+}
+
 <div
   className="c0"
 />

--- a/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/packages/components/src/Calendar/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -145,25 +145,18 @@ exports[`<CalendarDays /> renders correctly 1`] = `
 
 exports[`<CalendarEmptyDay /> renders correctly 1`] = `
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   width: calc(100% / 7);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   margin: 0 -1px -1px 0;
+  position: relative;
   border: 1px solid #F4F5F6;
   border-color: transparent;
 }
 
 .c0:after {
-  content: '';
+  content: "";
   display: block;
   padding-bottom: 100%;
 }


### PR DESCRIPTION
**What**

- Storybook was broken due to a missed grey rename.
- Calendar days had no height in Firefox.
- When multiple dates are selected the calendar had double borders.

**Fix**

- Update grey color
- Fix Firefox browser bug
- Use the parent element to control the border color
- Update to remove double borders
