### PR TITLE
feat: Add Modal component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
   "rules": {
     "react/jsx-filename-extension": 0,
     "import/no-extraneous-dependencies": 0,
-    "no-unused-expressions": ["error", { "allowTaggedTemplates": true }]
+    "no-unused-expressions": ["error", { "allowTaggedTemplates": true }],
+    "react/default-props-match-prop-types": 0
   },
   "env": {
     "jest": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,13 @@
   },
   "env": {
     "jest": true
-  }
+  },
+  "overrides": [{
+    "files": [
+      "**/*.story.js"
+    ],
+    "rules": {
+      "react/prop-types": 0
+    }
+  }]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "react/default-props-match-prop-types": 0
   },
   "env": {
+    "browser": true,
     "jest": true
   },
   "overrides": [{

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,7 +14,8 @@
   "devDependencies": {
     "@roo-ui/icons": "^0.39.1",
     "@roo-ui/test-utils": "^0.50.7",
-    "@roo-ui/themes": "^0.50.10"
+    "@roo-ui/themes": "^0.50.10",
+    "react-powerplug": "^1.0.0-rc.1"
   },
   "peerDependencies": {
     "clean-element": "^1.0.0",
@@ -29,6 +30,7 @@
     "date-fns": "^1.29.0",
     "dayzed": "^2.2.0",
     "downshift": "^2.0.10",
+    "react-modal": "^3.5.1",
     "react-onclickoutside": "^6.7.1",
     "react-popper": "^1.0.0",
     "react-text-mask": "^5.4.2"

--- a/packages/components/src/Modal/Modal.js
+++ b/packages/components/src/Modal/Modal.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import ReactModal from 'react-modal';
+import styled, { injectGlobal } from 'styled-components';
+import { themeGet } from 'styled-system';
+import { rgba } from 'polished';
+
+import ModalHeader from './components/ModalHeader';
+import ModalBody from './components/ModalBody';
+import ModalFooter from './components/ModalFooter';
+
+injectGlobal`
+  .ReactModal__Body--open { overflow: hidden; }
+`;
+
+const Modal = styled(({ className, ...props }) => (
+  <ReactModal
+    {...props}
+    className="ModalContent"
+    overlayClassName="ModalOverlay"
+    portalClassName={className}
+  />
+))`
+  .ModalOverlay {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    right: 0px;
+    bottom: 0px;
+    background-color: ${({ theme }) => rgba(theme.colors.greys.mineShaft, 0.8)};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .ModalContent {
+    position: relative;
+    top: auto;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    border: none;
+    background: ${themeGet('colors.white')};
+    overflow: auto;
+    border-radius: ${themeGet('radii.default')};
+    outline: none;
+    padding: 0px;
+    display: flex;
+    flex-direction: column;
+    max-height: 90%;
+    width: calc(100% - 20px);
+
+    @media (min-width: ${themeGet('breakpoints.0')}) {
+      flex: 0 1 660px;
+    }
+  }
+`;
+
+Modal.propTypes = {
+  ...ReactModal.propTypes,
+};
+
+Modal.header = ModalHeader;
+Modal.body = ModalBody;
+Modal.footer = ModalFooter;
+
+export default Modal;

--- a/packages/components/src/Modal/Modal.js
+++ b/packages/components/src/Modal/Modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactModal from 'react-modal';
 import styled, { injectGlobal } from 'styled-components';
 import { themeGet } from 'styled-system';
-import { rgba } from 'polished';
+import { rem, rgba } from 'polished';
 
 import ModalHeader from './components/ModalHeader';
 import ModalBody from './components/ModalBody';
@@ -47,10 +47,10 @@ const Modal = styled(({ className, ...props }) => (
     display: flex;
     flex-direction: column;
     max-height: 90%;
-    width: calc(100% - 20px);
+    width: calc(100% - ${themeGet('space.5')});
 
     @media (min-width: ${themeGet('breakpoints.0')}) {
-      flex: 0 1 660px;
+      flex: 0 1 ${rem('660px')};
     }
   }
 `;

--- a/packages/components/src/Modal/Modal.js
+++ b/packages/components/src/Modal/Modal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import styled, { injectGlobal } from 'styled-components';
 import { themeGet } from 'styled-system';
@@ -12,7 +13,7 @@ injectGlobal`
   .ReactModal__Body--open { overflow: hidden; }
 `;
 
-const Modal = styled(({ className, ...props }) => (
+const Modal = styled(({ className, width, ...props }) => (
   <ReactModal
     {...props}
     className="ModalContent"
@@ -50,13 +51,20 @@ const Modal = styled(({ className, ...props }) => (
     width: calc(100% - ${themeGet('space.5')});
 
     @media (min-width: ${themeGet('breakpoints.0')}) {
-      flex: 0 1 ${rem('660px')};
+      flex: 0 1 ${({ width }) => width};
     }
   }
 `;
 
 Modal.propTypes = {
   ...ReactModal.propTypes,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+Modal.defaultProps = {
+  width: rem(660),
+  role: 'dialog',
+  ariaHideApp: true,
 };
 
 Modal.header = ModalHeader;

--- a/packages/components/src/Modal/Model.story.js
+++ b/packages/components/src/Modal/Model.story.js
@@ -13,7 +13,7 @@ const ModalWrapper = ({ initial = true, variant }) => (
     {({ on, toggle }) => (
       <div>
         <Button primary onClick={toggle}>Open</Button>
-        <Modal isOpen={on} onRequestClose={toggle} shouldCloseOnOverlayClick>
+        <Modal isOpen={on} onRequestClose={toggle} ariaHideApp={false} shouldCloseOnOverlayClick>
           <Modal.header variant={variant} style={{ textTransform: 'capitalize' }}>
             {variant || 'Default'}
           </Modal.header>

--- a/packages/components/src/Modal/Model.story.js
+++ b/packages/components/src/Modal/Model.story.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withDocs } from 'storybook-readme';
+import { Toggle } from 'react-powerplug';
+
+import { Button } from '../..';
+
+import README from './README.md';
+import Modal from './Modal';
+
+const modalBodyDisplay = (
+  <Modal.body>
+    Lorem ipsum dolor sit amet<br />
+    Lorem ipsum dolor sit amet<br />
+    Lorem ipsum dolor sit amet<br />
+  </Modal.body>
+);
+
+const modalFooterDisplay = (
+  <Modal.footer>
+    <Button primary>Close</Button>
+  </Modal.footer>
+);
+
+storiesOf('Components|Modal', module)
+  .addDecorator(withDocs(README))
+  .add('<Modal />', () => (
+    <Toggle initial={false}>
+      {({ on, toggle }) => (
+        <div>
+          <Button primary onClick={toggle}>Open</Button>
+          <Modal isOpen={on} ariaHideApp={false}>
+            <Modal.header>
+              Default
+            </Modal.header>
+            {modalBodyDisplay}
+            <Modal.footer>
+              <Button primary onClick={toggle}>Close</Button>
+            </Modal.footer>
+          </Modal>
+        </div>
+      )}
+    </Toggle>
+  ))
+  .add('<Modal.header variant="info" />', () => (
+    <Modal isOpen ariaHideApp={false}>
+      <Modal.header variant="info">
+        Info
+      </Modal.header>
+      {modalBodyDisplay}
+      {modalFooterDisplay}
+    </Modal>
+  ))
+  .add('<Modal.header variant="success" />', () => (
+    <Modal isOpen ariaHideApp={false}>
+      <Modal.header variant="success">
+        Success
+      </Modal.header>
+      {modalBodyDisplay}
+      {modalFooterDisplay}
+    </Modal>
+  ))
+  .add('<Modal.header variant="error" />', () => (
+    <Modal isOpen ariaHideApp={false}>
+      <Modal.header variant="error">
+        Error
+      </Modal.header>
+      {modalBodyDisplay}
+      {modalFooterDisplay}
+    </Modal>
+  ));

--- a/packages/components/src/Modal/Model.story.js
+++ b/packages/components/src/Modal/Model.story.js
@@ -8,64 +8,40 @@ import { Button } from '../..';
 import README from './README.md';
 import Modal from './Modal';
 
-const modalBodyDisplay = (
-  <Modal.body>
-    Lorem ipsum dolor sit amet<br />
-    Lorem ipsum dolor sit amet<br />
-    Lorem ipsum dolor sit amet<br />
-  </Modal.body>
-);
-
-const modalFooterDisplay = (
-  <Modal.footer>
-    <Button primary>Close</Button>
-  </Modal.footer>
+const ModalWrapper = ({ initial = true, variant }) => (
+  <Toggle initial={initial}>
+    {({ on, toggle }) => (
+      <div>
+        <Button primary onClick={toggle}>Open</Button>
+        <Modal isOpen={on} onRequestClose={toggle} shouldCloseOnOverlayClick>
+          <Modal.header variant={variant} style={{ textTransform: 'capitalize' }}>
+            {variant || 'Default'}
+          </Modal.header>
+          <Modal.body>
+            Lorem ipsum dolor sit amet<br />
+            Lorem ipsum dolor sit amet<br />
+            Lorem ipsum dolor sit amet<br />
+          </Modal.body>
+          <Modal.footer>
+            <Button primary onClick={toggle}>Close</Button>
+          </Modal.footer>
+        </Modal>
+      </div>
+      )}
+  </Toggle>
 );
 
 storiesOf('Components|Modal', module)
   .addDecorator(withDocs(README))
   .add('<Modal />', () => (
-    <Toggle initial={false}>
-      {({ on, toggle }) => (
-        <div>
-          <Button primary onClick={toggle}>Open</Button>
-          <Modal isOpen={on} ariaHideApp={false}>
-            <Modal.header>
-              Default
-            </Modal.header>
-            {modalBodyDisplay}
-            <Modal.footer>
-              <Button primary onClick={toggle}>Close</Button>
-            </Modal.footer>
-          </Modal>
-        </div>
-      )}
-    </Toggle>
+    <ModalWrapper initial={false} />
   ))
   .add('<Modal.header variant="info" />', () => (
-    <Modal isOpen ariaHideApp={false}>
-      <Modal.header variant="info">
-        Info
-      </Modal.header>
-      {modalBodyDisplay}
-      {modalFooterDisplay}
-    </Modal>
+    <ModalWrapper variant="info" />
   ))
   .add('<Modal.header variant="success" />', () => (
-    <Modal isOpen ariaHideApp={false}>
-      <Modal.header variant="success">
-        Success
-      </Modal.header>
-      {modalBodyDisplay}
-      {modalFooterDisplay}
-    </Modal>
+    <ModalWrapper variant="success" />
   ))
   .add('<Modal.header variant="error" />', () => (
-    <Modal isOpen ariaHideApp={false}>
-      <Modal.header variant="error">
-        Error
-      </Modal.header>
-      {modalBodyDisplay}
-      {modalFooterDisplay}
-    </Modal>
+    <ModalWrapper variant="error" />
   ));

--- a/packages/components/src/Modal/Model.test.js
+++ b/packages/components/src/Modal/Model.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { axe } from 'jest-axe';
+import { mountWithTheme } from '@roo-ui/test-utils';
+import { qantas as theme } from '@roo-ui/themes';
+import Modal from './Modal';
+
+describe('<Modal />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mountWithTheme(
+      <Modal
+        title="Test Modal"
+        isOpen
+        role="dialog"
+        ariaHideApp={false}
+      />,
+      theme,
+    );
+  });
+
+  it('has no accessibility errors', async () => {
+    expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('has display name', () => {
+    expect(wrapper.find(Modal).name()).toBe('Modal');
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/Modal/Model.test.js
+++ b/packages/components/src/Modal/Model.test.js
@@ -2,9 +2,14 @@ import React from 'react';
 import { axe } from 'jest-axe';
 import { mountWithTheme } from '@roo-ui/test-utils';
 import { qantas as theme } from '@roo-ui/themes';
+import ReactModal from 'react-modal';
 import Modal from './Modal';
 
 describe('<Modal />', () => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  ReactModal.setAppElement(root);
+
   let wrapper;
 
   beforeEach(() => {
@@ -12,8 +17,6 @@ describe('<Modal />', () => {
       <Modal
         title="Test Modal"
         isOpen
-        role="dialog"
-        ariaHideApp={false}
       />,
       theme,
     );

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -1,0 +1,50 @@
+# Modal
+
+<!-- STORY -->
+
+## Installation
+
+```shell
+$ yarn add @roo-ui/components
+```
+
+## Example
+
+```js
+import { Modal } from '@roo-ui/components';
+
+export default (
+  <Modal isOpen={isOpen}>
+    <Modal.header>Default</Modal.header>
+    <Modal.body>
+      Lorem ipsum dolor sit amet<br />
+      Lorem ipsum dolor sit amet<br />
+      Lorem ipsum dolor sit amet<br />
+    </Modal.body>
+    <Modal.footer>
+      <Button primary onClick={toggleIsOpen}>Close</Button>
+    </Modal.footer>
+  </Modal>
+);
+```
+
+## Properties
+
+### Modal
+
+This component support same props as [react-modal](https://github.com/reactjs/react-modal/blob/v3.5.1/docs/README.md#general-usage-usage).
+
+### Modal.header
+
+| Name        | Description                                                             | Type     | Default   | Required? |
+|-------------|-------------------------------------------------------------------------|----------|-----------|-----------|
+| `icon`      | render an icon                                                          | `shape`  | -         | -         |
+| `variant`   | `alertStyle` from theme. One of `default`, `info`, `success` or `error` | `string` | 'default' | -         |
+
+This component support same props as [Box](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Box/README.md).
+
+### Modal.body
+This component support same props as [Box](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Box/README.md).
+
+### Modal.footer
+This component support same props as [Flex](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Flex/README.md).

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -32,9 +32,9 @@ export default (
 
 ### Modal
 
-| Name    | Description                                       | Type            | Default        | Required? |
-|---------|---------------------------------------------------|-----------------|----------------|-----------|
-| `width` | Max width of the modal after the first breakpoint | `number|string` | `rem('660px')` | -         |
+| Name    | Description                                       | Type                  | Default        | Required? |
+|---------|---------------------------------------------------|-----------------------|----------------|-----------|
+| `width` | Max width of the modal after the first breakpoint | `number` or `string`  | `rem('660px')` | -         |
 
 This component support same props as [react-modal](https://github.com/reactjs/react-modal/blob/v3.5.1/docs/README.md#general-usage-usage).
 

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -14,7 +14,7 @@ $ yarn add @roo-ui/components
 import { Modal } from '@roo-ui/components';
 
 export default (
-  <Modal isOpen={isOpen}>
+  <Modal isOpen={isOpen} onRequestClose={toggleIsOpen} shouldCloseOnOverlayClick>
     <Modal.header>Default</Modal.header>
     <Modal.body>
       Lorem ipsum dolor sit amet<br />
@@ -31,6 +31,10 @@ export default (
 ## Properties
 
 ### Modal
+
+| Name    | Description                                       | Type            | Default        | Required? |
+|---------|---------------------------------------------------|-----------------|----------------|-----------|
+| `width` | Max width of the modal after the first breakpoint | `number|string` | `rem('660px')` | -         |
 
 This component support same props as [react-modal](https://github.com/reactjs/react-modal/blob/v3.5.1/docs/README.md#general-usage-usage).
 

--- a/packages/components/src/Modal/__snapshots__/Model.test.js.snap
+++ b/packages/components/src/Modal/__snapshots__/Model.test.js.snap
@@ -42,14 +42,14 @@ exports[`<Modal /> renders correctly 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 90%;
-  width: calc(100% - 20px);
+  width: calc(100% - 1.25rem);
 }
 
 @media (min-width:40rem) {
   .c0 .ModalContent {
-    -webkit-flex: 0 1 660px;
-    -ms-flex: 0 1 660px;
-    flex: 0 1 660px;
+    -webkit-flex: 0 1 41.25rem;
+    -ms-flex: 0 1 41.25rem;
+    flex: 0 1 41.25rem;
   }
 }
 

--- a/packages/components/src/Modal/__snapshots__/Model.test.js.snap
+++ b/packages/components/src/Modal/__snapshots__/Model.test.js.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Modal /> renders correctly 1`] = `
+.c0 .ModalOverlay {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(34,34,34,0.8);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .ModalContent {
+  position: relative;
+  top: auto;
+  left: auto;
+  right: auto;
+  bottom: auto;
+  border: none;
+  background: #FFFFFF;
+  overflow: auto;
+  border-radius: 4px;
+  outline: none;
+  padding: 0px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: 90%;
+  width: calc(100% - 20px);
+}
+
+@media (min-width:40rem) {
+  .c0 .ModalContent {
+    -webkit-flex: 0 1 660px;
+    -ms-flex: 0 1 660px;
+    flex: 0 1 660px;
+  }
+}
+
+<Modal
+  ariaHideApp={false}
+  isOpen={true}
+  role="dialog"
+  title="Test Modal"
+>
+  <Component
+    ariaHideApp={false}
+    className="c0"
+    isOpen={true}
+    role="dialog"
+    title="Test Modal"
+  >
+    <Modal
+      ariaHideApp={false}
+      bodyOpenClassName="ReactModal__Body--open"
+      className="ModalContent"
+      closeTimeoutMS={0}
+      isOpen={true}
+      overlayClassName="ModalOverlay"
+      parentSelector={[Function]}
+      portalClassName="Modal-yQUFA c0"
+      role="dialog"
+      shouldCloseOnEsc={true}
+      shouldCloseOnOverlayClick={true}
+      shouldFocusAfterRender={true}
+      shouldReturnFocusAfterClose={true}
+      title="Test Modal"
+    >
+      <ModalPortal
+        ariaHideApp={false}
+        bodyOpenClassName="ReactModal__Body--open"
+        className="ModalContent"
+        closeTimeoutMS={0}
+        defaultStyles={
+          Object {
+            "content": Object {
+              "WebkitOverflowScrolling": "touch",
+              "background": "#fff",
+              "border": "1px solid #ccc",
+              "borderRadius": "4px",
+              "bottom": "40px",
+              "left": "40px",
+              "outline": "none",
+              "overflow": "auto",
+              "padding": "20px",
+              "position": "absolute",
+              "right": "40px",
+              "top": "40px",
+            },
+            "overlay": Object {
+              "backgroundColor": "rgba(255, 255, 255, 0.75)",
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            },
+          }
+        }
+        isOpen={true}
+        overlayClassName="ModalOverlay"
+        parentSelector={[Function]}
+        portalClassName="Modal-yQUFA c0"
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+        style={
+          Object {
+            "content": Object {},
+            "overlay": Object {},
+          }
+        }
+        title="Test Modal"
+      >
+        <div
+          aria-modal="true"
+          className="ReactModal__Overlay ReactModal__Overlay--after-open ModalOverlay"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          style={Object {}}
+        >
+          <div
+            className="ReactModal__Content ReactModal__Content--after-open ModalContent"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            role="dialog"
+            style={Object {}}
+            tabIndex="-1"
+          />
+        </div>
+      </ModalPortal>
+    </Modal>
+  </Component>
+</Modal>
+`;

--- a/packages/components/src/Modal/__snapshots__/Model.test.js.snap
+++ b/packages/components/src/Modal/__snapshots__/Model.test.js.snap
@@ -58,6 +58,7 @@ exports[`<Modal /> renders correctly 1`] = `
   isOpen={true}
   role="dialog"
   title="Test Modal"
+  width="41.25rem"
 >
   <Component
     ariaHideApp={false}
@@ -65,6 +66,7 @@ exports[`<Modal /> renders correctly 1`] = `
     isOpen={true}
     role="dialog"
     title="Test Modal"
+    width="41.25rem"
   >
     <Modal
       ariaHideApp={false}

--- a/packages/components/src/Modal/__snapshots__/Model.test.js.snap
+++ b/packages/components/src/Modal/__snapshots__/Model.test.js.snap
@@ -54,14 +54,14 @@ exports[`<Modal /> renders correctly 1`] = `
 }
 
 <Modal
-  ariaHideApp={false}
+  ariaHideApp={true}
   isOpen={true}
   role="dialog"
   title="Test Modal"
   width="41.25rem"
 >
   <Component
-    ariaHideApp={false}
+    ariaHideApp={true}
     className="c0"
     isOpen={true}
     role="dialog"
@@ -69,7 +69,7 @@ exports[`<Modal /> renders correctly 1`] = `
     width="41.25rem"
   >
     <Modal
-      ariaHideApp={false}
+      ariaHideApp={true}
       bodyOpenClassName="ReactModal__Body--open"
       className="ModalContent"
       closeTimeoutMS={0}
@@ -85,7 +85,7 @@ exports[`<Modal /> renders correctly 1`] = `
       title="Test Modal"
     >
       <ModalPortal
-        ariaHideApp={false}
+        ariaHideApp={true}
         bodyOpenClassName="ReactModal__Body--open"
         className="ModalContent"
         closeTimeoutMS={0}

--- a/packages/components/src/Modal/components/ModalBody/ModalBody.js
+++ b/packages/components/src/Modal/components/ModalBody/ModalBody.js
@@ -14,10 +14,10 @@ const ModalBody = ({ children, ...props }) => (
 ModalBody.displayName = 'Modal.body';
 
 ModalBody.defaultProps = {
-  textAlign: 'center', // eslint-disable-line react/default-props-match-prop-types
-  px: 11, // eslint-disable-line react/default-props-match-prop-types
-  pt: 7, // eslint-disable-line react/default-props-match-prop-types
-  pb: 10, // eslint-disable-line react/default-props-match-prop-types
+  textAlign: 'center',
+  px: 11,
+  pt: 7,
+  pb: 10,
 };
 
 ModalBody.propTypes = {

--- a/packages/components/src/Modal/components/ModalBody/ModalBody.js
+++ b/packages/components/src/Modal/components/ModalBody/ModalBody.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Box, Text } from '../../..';
+
+const ModalBody = ({ children, ...props }) => (
+  <Box {...props}>
+    <Text fontSize="xl" color="text">
+      {children}
+    </Text>
+  </Box>
+);
+
+ModalBody.displayName = 'Modal.body';
+
+ModalBody.defaultProps = {
+  textAlign: 'center', // eslint-disable-line react/default-props-match-prop-types
+  px: 11, // eslint-disable-line react/default-props-match-prop-types
+  pt: 7, // eslint-disable-line react/default-props-match-prop-types
+  pb: 10, // eslint-disable-line react/default-props-match-prop-types
+};
+
+ModalBody.propTypes = {
+  children: PropTypes.node.isRequired,
+  ...Box.propTypes,
+};
+
+export default ModalBody;

--- a/packages/components/src/Modal/components/ModalBody/ModalBody.test.js
+++ b/packages/components/src/Modal/components/ModalBody/ModalBody.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { axe } from 'jest-axe';
+import { mountWithTheme, shallowWithTheme } from '@roo-ui/test-utils';
+import { qantas as theme } from '@roo-ui/themes';
+import ModalBody from './ModalBody';
+
+describe('<ModalBody />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mountWithTheme(
+      <ModalBody>
+        Lorem ipsum dolor sit amet
+      </ModalBody>,
+      theme,
+    );
+  });
+
+  it('has no accessibility errors', async () => {
+    expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('has display name', () => {
+    expect(wrapper.find(ModalBody).name()).toBe('Modal.body');
+  });
+
+  it('renders correctly', () => {
+    expect(shallowWithTheme(
+      <ModalBody>
+        Lorem ipsum dolor sit amet
+      </ModalBody>,
+      theme,
+    )).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/Modal/components/ModalBody/ModalBody.test.js
+++ b/packages/components/src/Modal/components/ModalBody/ModalBody.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { axe } from 'jest-axe';
-import { mountWithTheme, shallowWithTheme } from '@roo-ui/test-utils';
+import { shallowWithTheme } from '@roo-ui/test-utils';
 import { qantas as theme } from '@roo-ui/themes';
 import ModalBody from './ModalBody';
 
@@ -8,7 +8,7 @@ describe('<ModalBody />', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mountWithTheme(
+    wrapper = shallowWithTheme(
       <ModalBody>
         Lorem ipsum dolor sit amet
       </ModalBody>,
@@ -21,15 +21,10 @@ describe('<ModalBody />', () => {
   });
 
   it('has display name', () => {
-    expect(wrapper.find(ModalBody).name()).toBe('Modal.body');
+    expect(ModalBody.displayName).toBe('Modal.body');
   });
 
   it('renders correctly', () => {
-    expect(shallowWithTheme(
-      <ModalBody>
-        Lorem ipsum dolor sit amet
-      </ModalBody>,
-      theme,
-    )).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/components/src/Modal/components/ModalBody/__snapshots__/ModalBody.test.js.snap
+++ b/packages/components/src/Modal/components/ModalBody/__snapshots__/ModalBody.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ModalBody /> renders correctly 1`] = `
+<Box
+  pb={10}
+  pt={7}
+  px={11}
+  textAlign="center"
+>
+  <Text
+    blacklist={
+      Array [
+        "textStyle",
+        "color",
+        "bg",
+        "fontSize",
+        "f",
+        "fontWeight",
+        "letterSpacing",
+        "lineHeight",
+        "m",
+        "mt",
+        "mr",
+        "mb",
+        "ml",
+        "mx",
+        "my",
+        "p",
+        "pt",
+        "pr",
+        "pb",
+        "pl",
+        "px",
+        "py",
+        "textAlign",
+        "align",
+        "textDecoration",
+        "hidden",
+      ]
+    }
+    color="text"
+    fontSize="xl"
+    hidden={false}
+    textStyle="text"
+  >
+    Lorem ipsum dolor sit amet
+  </Text>
+</Box>
+`;

--- a/packages/components/src/Modal/components/ModalBody/index.js
+++ b/packages/components/src/Modal/components/ModalBody/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModalBody';

--- a/packages/components/src/Modal/components/ModalFooter/ModalFooter.js
+++ b/packages/components/src/Modal/components/ModalFooter/ModalFooter.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Flex } from '../../..';
+
+const ModalFooter = ({ children, ...props }) => (
+  <Flex {...props}>
+    {children}
+  </Flex>
+);
+
+ModalFooter.displayName = 'Modal.footer';
+
+ModalFooter.defaultProps = {
+  alignItems: 'center', // eslint-disable-line react/default-props-match-prop-types
+  justifyContent: 'center', // eslint-disable-line react/default-props-match-prop-types
+  px: 11, // eslint-disable-line react/default-props-match-prop-types
+  pb: 11, // eslint-disable-line react/default-props-match-prop-types
+};
+
+ModalFooter.propTypes = {
+  children: PropTypes.node.isRequired,
+  ...Flex.propTypes,
+};
+
+export default ModalFooter;

--- a/packages/components/src/Modal/components/ModalFooter/ModalFooter.js
+++ b/packages/components/src/Modal/components/ModalFooter/ModalFooter.js
@@ -12,10 +12,10 @@ const ModalFooter = ({ children, ...props }) => (
 ModalFooter.displayName = 'Modal.footer';
 
 ModalFooter.defaultProps = {
-  alignItems: 'center', // eslint-disable-line react/default-props-match-prop-types
-  justifyContent: 'center', // eslint-disable-line react/default-props-match-prop-types
-  px: 11, // eslint-disable-line react/default-props-match-prop-types
-  pb: 11, // eslint-disable-line react/default-props-match-prop-types
+  alignItems: 'center',
+  justifyContent: 'center',
+  px: 11,
+  pb: 11,
 };
 
 ModalFooter.propTypes = {

--- a/packages/components/src/Modal/components/ModalFooter/ModalFooter.test.js
+++ b/packages/components/src/Modal/components/ModalFooter/ModalFooter.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { axe } from 'jest-axe';
-import { mountWithTheme, shallowWithTheme } from '@roo-ui/test-utils';
+import { shallowWithTheme } from '@roo-ui/test-utils';
 import { qantas as theme } from '@roo-ui/themes';
 import ModalFooter from './ModalFooter';
 
@@ -8,7 +8,7 @@ describe('<ModalFooter />', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mountWithTheme(
+    wrapper = shallowWithTheme(
       <ModalFooter>
         Lorem ipsum dolor sit amet
       </ModalFooter>,
@@ -21,15 +21,10 @@ describe('<ModalFooter />', () => {
   });
 
   it('has display name', () => {
-    expect(wrapper.find(ModalFooter).name()).toBe('Modal.footer');
+    expect(ModalFooter.displayName).toBe('Modal.footer');
   });
 
   it('renders correctly', () => {
-    expect(shallowWithTheme(
-      <ModalFooter>
-        Lorem ipsum dolor sit amet
-      </ModalFooter>,
-      theme,
-    )).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/components/src/Modal/components/ModalFooter/ModalFooter.test.js
+++ b/packages/components/src/Modal/components/ModalFooter/ModalFooter.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { axe } from 'jest-axe';
+import { mountWithTheme, shallowWithTheme } from '@roo-ui/test-utils';
+import { qantas as theme } from '@roo-ui/themes';
+import ModalFooter from './ModalFooter';
+
+describe('<ModalFooter />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mountWithTheme(
+      <ModalFooter>
+        Lorem ipsum dolor sit amet
+      </ModalFooter>,
+      theme,
+    );
+  });
+
+  it('has no accessibility errors', async () => {
+    expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('has display name', () => {
+    expect(wrapper.find(ModalFooter).name()).toBe('Modal.footer');
+  });
+
+  it('renders correctly', () => {
+    expect(shallowWithTheme(
+      <ModalFooter>
+        Lorem ipsum dolor sit amet
+      </ModalFooter>,
+      theme,
+    )).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/Modal/components/ModalFooter/__snapshots__/ModalFooter.test.js.snap
+++ b/packages/components/src/Modal/components/ModalFooter/__snapshots__/ModalFooter.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ModalFooter /> renders correctly 1`] = `
+<Box
+  alignItems="center"
+  justifyContent="center"
+  pb={11}
+  px={11}
+>
+  Lorem ipsum dolor sit amet
+</Box>
+`;

--- a/packages/components/src/Modal/components/ModalFooter/index.js
+++ b/packages/components/src/Modal/components/ModalFooter/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModalFooter';

--- a/packages/components/src/Modal/components/ModalHeader/ModalHeader.js
+++ b/packages/components/src/Modal/components/ModalHeader/ModalHeader.js
@@ -34,7 +34,6 @@ const ModalHeader = withTheme(({
 
 ModalHeader.displayName = 'Modal.header';
 ModalHeader.defaultProps = {
-  ...Box.defaultProps,
   variant: 'default',
 };
 
@@ -42,6 +41,7 @@ ModalHeader.propTypes = {
   children: PropTypes.node.isRequired,
   icon: PropTypes.shape(Icon.propTypes),
   variant: PropTypes.string,
+  ...Box.propTypes,
 };
 
 export default ModalHeader;

--- a/packages/components/src/Modal/components/ModalHeader/ModalHeader.js
+++ b/packages/components/src/Modal/components/ModalHeader/ModalHeader.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withTheme } from 'styled-components';
+import { themeGet } from 'styled-system';
+
+import { Text, Flex, Box, Icon } from '../../..';
+
+const ModalHeader = withTheme(({
+  theme,
+  variant,
+  children,
+  ...props
+}) => {
+  const { icon, bg } = {
+    ...themeGet(`alertStyles.${variant}`)({ theme }),
+    ...props,
+  };
+
+  return (
+    <Box {...props} bg={bg}>
+      <Flex px={11} py={9} justifyContent="center" alignItems="center">
+        {icon && (
+          <Box pr={3}>
+            <Icon {...icon} />
+          </Box>
+        )}
+        <Text mb={0} fontSize="xl" textAlign="left" fontWeight="bold">
+          {children}
+        </Text>
+      </Flex>
+    </Box>
+  );
+});
+
+ModalHeader.displayName = 'Modal.header';
+ModalHeader.defaultProps = {
+  ...Box.defaultProps,
+  variant: 'default',
+};
+
+ModalHeader.propTypes = {
+  children: PropTypes.node.isRequired,
+  icon: PropTypes.shape(Icon.propTypes),
+  variant: PropTypes.string,
+};
+
+export default ModalHeader;

--- a/packages/components/src/Modal/components/ModalHeader/ModalHeader.test.js
+++ b/packages/components/src/Modal/components/ModalHeader/ModalHeader.test.js
@@ -8,6 +8,10 @@ describe('<ModalHeader />', () => {
   const theme = { alertStyles: qantas.alertStyles };
   let wrapper;
 
+  it('has display name', () => {
+    expect(ModalHeader.displayName).toBe('Modal.header');
+  });
+
   describe('default', () => {
     beforeEach(() => {
       wrapper = mountWithTheme(

--- a/packages/components/src/Modal/components/ModalHeader/ModalHeader.test.js
+++ b/packages/components/src/Modal/components/ModalHeader/ModalHeader.test.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { axe } from 'jest-axe';
+import { mountWithTheme, shallowWithTheme } from '@roo-ui/test-utils';
+import { qantas } from '@roo-ui/themes';
+import ModalHeader from './ModalHeader';
+
+describe('<ModalHeader />', () => {
+  const theme = { alertStyles: qantas.alertStyles };
+  let wrapper;
+
+  describe('default', () => {
+    beforeEach(() => {
+      wrapper = mountWithTheme(
+        <ModalHeader >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      );
+    });
+
+    it('has no accessibility errors', async () => {
+      expect(await axe(wrapper.html())).toHaveNoViolations();
+    });
+
+    it('have display name', () => {
+      expect(wrapper.find(ModalHeader).name()).toBe('Modal.header');
+    });
+
+    it('renders correctly', () => {
+      expect(shallowWithTheme(
+        <ModalHeader >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      )).toMatchSnapshot();
+    });
+  });
+
+  describe('variant = info', () => {
+    beforeEach(() => {
+      wrapper = mountWithTheme(
+        <ModalHeader variant="info" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      );
+    });
+
+    it('has no accessibility errors', async () => {
+      expect(await axe(wrapper.html())).toHaveNoViolations();
+    });
+
+    it('have display name', () => {
+      expect(wrapper.find(ModalHeader).name()).toBe('Modal.header');
+    });
+
+    it('renders correctly', () => {
+      expect(shallowWithTheme(
+        <ModalHeader variant="info" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      )).toMatchSnapshot();
+    });
+  });
+
+  describe('variant = success', () => {
+    beforeEach(() => {
+      wrapper = mountWithTheme(
+        <ModalHeader variant="success" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      );
+    });
+
+    it('has no accessibility errors', async () => {
+      expect(await axe(wrapper.html())).toHaveNoViolations();
+    });
+
+    it('have display name', () => {
+      expect(wrapper.find(ModalHeader).name()).toBe('Modal.header');
+    });
+
+    it('renders correctly', () => {
+      expect(shallowWithTheme(
+        <ModalHeader variant="success" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      )).toMatchSnapshot();
+    });
+  });
+
+  describe('variant = error', () => {
+    beforeEach(() => {
+      wrapper = mountWithTheme(
+        <ModalHeader variant="error" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      );
+    });
+
+    it('has no accessibility errors', async () => {
+      expect(await axe(wrapper.html())).toHaveNoViolations();
+    });
+
+    it('have display name', () => {
+      expect(wrapper.find(ModalHeader).name()).toBe('Modal.header');
+    });
+
+    it('renders correctly', () => {
+      expect(shallowWithTheme(
+        <ModalHeader variant="error" >
+          Lorem ipsum dolor sit amet
+        </ModalHeader>,
+        theme,
+      )).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/components/src/Modal/components/ModalHeader/__snapshots__/ModalHeader.test.js.snap
+++ b/packages/components/src/Modal/components/ModalHeader/__snapshots__/ModalHeader.test.js.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ModalHeader /> default renders correctly 1`] = `
+<Component
+  theme={
+    Object {
+      "alertStyles": Object {
+        "default": Object {
+          "bg": "greys.porcelain",
+        },
+        "error": Object {
+          "bg": "ui.errorBackground",
+          "icon": Object {
+            "color": "ui.error",
+            "name": "warning",
+          },
+        },
+        "info": Object {
+          "bg": "ui.infoBackground",
+          "icon": Object {
+            "color": "greys.charcoal",
+            "name": "info",
+          },
+        },
+        "success": Object {
+          "bg": "ui.successBackground",
+          "icon": Object {
+            "color": "ui.success",
+            "name": "checkCircle",
+          },
+        },
+      },
+    }
+  }
+  variant="default"
+>
+  Lorem ipsum dolor sit amet
+</Component>
+`;
+
+exports[`<ModalHeader /> variant = error renders correctly 1`] = `
+<Component
+  theme={
+    Object {
+      "alertStyles": Object {
+        "default": Object {
+          "bg": "greys.porcelain",
+        },
+        "error": Object {
+          "bg": "ui.errorBackground",
+          "icon": Object {
+            "color": "ui.error",
+            "name": "warning",
+          },
+        },
+        "info": Object {
+          "bg": "ui.infoBackground",
+          "icon": Object {
+            "color": "greys.charcoal",
+            "name": "info",
+          },
+        },
+        "success": Object {
+          "bg": "ui.successBackground",
+          "icon": Object {
+            "color": "ui.success",
+            "name": "checkCircle",
+          },
+        },
+      },
+    }
+  }
+  variant="error"
+>
+  Lorem ipsum dolor sit amet
+</Component>
+`;
+
+exports[`<ModalHeader /> variant = info renders correctly 1`] = `
+<Component
+  theme={
+    Object {
+      "alertStyles": Object {
+        "default": Object {
+          "bg": "greys.porcelain",
+        },
+        "error": Object {
+          "bg": "ui.errorBackground",
+          "icon": Object {
+            "color": "ui.error",
+            "name": "warning",
+          },
+        },
+        "info": Object {
+          "bg": "ui.infoBackground",
+          "icon": Object {
+            "color": "greys.charcoal",
+            "name": "info",
+          },
+        },
+        "success": Object {
+          "bg": "ui.successBackground",
+          "icon": Object {
+            "color": "ui.success",
+            "name": "checkCircle",
+          },
+        },
+      },
+    }
+  }
+  variant="info"
+>
+  Lorem ipsum dolor sit amet
+</Component>
+`;
+
+exports[`<ModalHeader /> variant = success renders correctly 1`] = `
+<Component
+  theme={
+    Object {
+      "alertStyles": Object {
+        "default": Object {
+          "bg": "greys.porcelain",
+        },
+        "error": Object {
+          "bg": "ui.errorBackground",
+          "icon": Object {
+            "color": "ui.error",
+            "name": "warning",
+          },
+        },
+        "info": Object {
+          "bg": "ui.infoBackground",
+          "icon": Object {
+            "color": "greys.charcoal",
+            "name": "info",
+          },
+        },
+        "success": Object {
+          "bg": "ui.successBackground",
+          "icon": Object {
+            "color": "ui.success",
+            "name": "checkCircle",
+          },
+        },
+      },
+    }
+  }
+  variant="success"
+>
+  Lorem ipsum dolor sit amet
+</Component>
+`;

--- a/packages/components/src/Modal/components/ModalHeader/index.js
+++ b/packages/components/src/Modal/components/ModalHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModalHeader';

--- a/packages/components/src/Modal/index.js
+++ b/packages/components/src/Modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -28,6 +28,7 @@ export { default as Truncate } from './Truncate';
 export { default as CharacterCount } from './CharacterCount';
 export { default as Checkbox } from './Checkbox';
 export { default as MaskedInput } from './MaskedInput';
+export { default as Modal } from './Modal';
 export { default as Textarea } from './Textarea';
 export { default as Radio } from './Radio';
 export { default as Select } from './Select';

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -14,6 +14,7 @@ const greys = {
   alto: '#DADADA',
   porcelain: '#F4F5F6',
   dusty: '#999999',
+  mineShaft: '#222222',
 };
 
 const namedColors = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.49.tgz#03b3bf07eb982072c8e851dd2ddd5110282e61bf"
+  dependencies:
+    core-js "^2.5.6"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -1960,8 +1967,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.0.3:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -2658,6 +2665,10 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+
+core-js@^2.5.6:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7729,6 +7740,15 @@ react-modal@^3.3.2:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-modal@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.5.1.tgz#33d38527def90ea324848f7d63e53acc4468a451"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
+
 react-onclickoutside@^6.5.0, react-onclickoutside@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
@@ -7743,6 +7763,12 @@ react-popper@^1.0.0:
     prop-types "^15.6.1"
     typed-styles "^0.0.5"
     warning "^3.0.0"
+
+react-powerplug@^1.0.0-rc.1:
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-powerplug/-/react-powerplug-1.0.0-rc.1.tgz#6b3bc57e31684e8bc36baa7a65af602ba0e31145"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.49"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -7993,7 +8019,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -8856,14 +8882,13 @@ style-loader@^0.20.3:
     schema-utils "^0.4.5"
 
 styled-components@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.3.tgz#09e702055ab11f7a8eab8229b1c0d0b855095686"
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.2.tgz#8f518419932327e47fe9144824e3184b3e2da95d"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
     fbjs "^0.8.16"
     hoist-non-react-statics "^2.5.0"
-    is-plain-object "^2.0.1"
     prop-types "^15.5.4"
     react-is "^16.3.1"
     stylis "^3.5.0"
@@ -8891,8 +8916,8 @@ stylis@^3.0.0:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 stylis@^3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.1.tgz#fd341d59f57f9aeb412bc14c9d8a8670b438e03b"
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What

New `Modal` Component:

#### Modal

This component support same props as [react-modal](https://github.com/reactjs/react-modal/blob/v3.5.1/docs/README.md#general-usage-usage).

#### Modal.header

| Name        | Description                                                             | Type     | Default   | Required? |
|-------------|-------------------------------------------------------------------------|----------|-----------|-----------|
| `icon`      | render an icon                                                          | `shape`  | -         | -         |
| `variant`   | `alertStyle` from theme. One of `default`, `info`, `success` or `error` | `string` | 'default' | -         |

This component support same props as [Box](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Box/README.md).

#### Modal.body
This component support same props as [Box](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Box/README.md).

#### Modal.footer
This component support same props as [Flex](https://github.com/hooroo/roo-ui/tree/master/packages/components/src/Flex/README.md).


### StoryBook
![roo-ui-modal](https://user-images.githubusercontent.com/5798940/44069290-6201e91c-9fc1-11e8-8108-118d0a7f7c30.gif)

- `<Modal.header />`
![screen shot 2018-08-14 at 12 57 36 pm](https://user-images.githubusercontent.com/5798940/44069358-ad7aa41a-9fc1-11e8-8eec-dad60975990e.png)

- `<Modal.header variant="info" />`
![screen shot 2018-08-14 at 12 47 18 pm](https://user-images.githubusercontent.com/5798940/44069396-e083dce6-9fc1-11e8-96be-e6e627a0bd3f.png)

- `<Modal.header variant="success" />`
![screen shot 2018-08-14 at 12 47 38 pm](https://user-images.githubusercontent.com/5798940/44069403-e6f07ef4-9fc1-11e8-83cb-7ed6466b7e54.png)

- `<Modal.header variant="error" />`
![screen shot 2018-08-14 at 12 47 52 pm](https://user-images.githubusercontent.com/5798940/44069410-ed82892e-9fc1-11e8-9c19-97b5bd627914.png)
