### PR TITLE
fix: pass theme to child components; update snapshots

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.js.snap
@@ -5,12 +5,24 @@ exports[`<Autocomplete /> renders correctly 1`] = `
   display: block;
   width: 100%;
   margin: 0;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  line-height: 1.35;
+  color: #323232;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
   outline: 0;
-  -webkit-transition: border-color;
-  transition: border-color;
+  -webkit-transition: border-color 200ms ease-in;
+  transition: border-color 200ms ease-in;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+}
+
+.c2:focus {
+  border-color: #8DE2E0;
 }
 
 .c2[readonly] {
@@ -19,16 +31,20 @@ exports[`<Autocomplete /> renders correctly 1`] = `
   padding-left: 0;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2::-webkit-input-placeholder {
+  color: #666666;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2::-moz-placeholder {
+  color: #666666;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2:-ms-input-placeholder {
+  color: #666666;
+}
+
+.c2::placeholder {
+  color: #666666;
 }
 
 .c2::-ms-clear {
@@ -39,6 +55,10 @@ exports[`<Autocomplete /> renders correctly 1`] = `
   display: block;
   width: 100%;
   margin: 0;
+  margin-bottom: 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #323232;
 }
 
 .c0 {
@@ -392,12 +412,24 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
   display: block;
   width: 100%;
   margin: 0;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  line-height: 1.35;
+  color: #323232;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
   outline: 0;
-  -webkit-transition: border-color;
-  transition: border-color;
+  -webkit-transition: border-color 200ms ease-in;
+  transition: border-color 200ms ease-in;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+}
+
+.c2:focus {
+  border-color: #8DE2E0;
 }
 
 .c2[readonly] {
@@ -406,16 +438,20 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
   padding-left: 0;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2::-webkit-input-placeholder {
+  color: #666666;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2::-moz-placeholder {
+  color: #666666;
 }
 
-.c2::-ms-clear {
-  display: none;
+.c2:-ms-input-placeholder {
+  color: #666666;
+}
+
+.c2::placeholder {
+  color: #666666;
 }
 
 .c2::-ms-clear {
@@ -426,6 +462,10 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
   display: block;
   width: 100%;
   margin: 0;
+  margin-bottom: 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #323232;
 }
 
 .c0 {
@@ -435,7 +475,9 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
 .c3 {
   position: absolute;
   width: 100%;
-  margin-top: -;
+  margin-top: -0.75rem;
+  border-left: 1px solid #DADADA;
+  border-right: 1px solid #DADADA;
   z-index: 2;
   max-height: 14.375rem;
   overflow-y: scroll;
@@ -443,7 +485,10 @@ exports[`<Autocomplete /> when open renders correctly 1`] = `
 }
 
 .c4 {
-  border-left: transparent;
+  background-color: #F4F5F6;
+  border-bottom: 1px solid #DADADA;
+  border-left: 1px solid transparent;
+  padding: 0.75rem 1rem;
 }
 
 <Autocomplete

--- a/packages/components/src/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/packages/components/src/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -20,8 +20,26 @@ exports[`<Checkbox /> renders correctly 1`] = `
   display: inline-block;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
+  border-radius: 4px;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 .c3 {
@@ -31,6 +49,8 @@ exports[`<Checkbox /> renders correctly 1`] = `
   flex: none;
   position: absolute;
   display: none;
+  color: #323232;
+  padding: 0.25rem;
   top: 0;
   left: -0.125rem;
 }
@@ -316,8 +336,26 @@ exports[`<Checkbox /> when checked renders correctly 1`] = `
   display: inline-block;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
+  border-radius: 4px;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 .c3 {
@@ -327,6 +365,8 @@ exports[`<Checkbox /> when checked renders correctly 1`] = `
   flex: none;
   position: absolute;
   display: none;
+  color: #323232;
+  padding: 0.25rem;
   top: 0;
   left: -0.125rem;
 }
@@ -616,8 +656,26 @@ exports[`<Checkbox /> when disabled renders correctly 1`] = `
   display: inline-block;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
+  border-radius: 4px;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 .c3 {
@@ -627,6 +685,8 @@ exports[`<Checkbox /> when disabled renders correctly 1`] = `
   flex: none;
   position: absolute;
   display: none;
+  color: #323232;
+  padding: 0.25rem;
   top: 0;
   left: -0.125rem;
 }

--- a/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
@@ -158,6 +158,8 @@ exports[`<Popover /> when popover is open renders correctly 1`] = `
 .c0 {
   z-index: 1;
   margin: 0.75rem;
+  background: #F4F5F6;
+  border: 2px solid #DADADA;
 }
 
 .c2 {

--- a/packages/components/src/Radio/__snapshots__/Radio.test.js.snap
+++ b/packages/components/src/Radio/__snapshots__/Radio.test.js.snap
@@ -21,17 +21,39 @@ exports[`<Radio /> renders correctly 1`] = `
   position: relative;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
   border-radius: 50%;
   z-index: 1;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
 }
 
 input:checked + .c2:after {
   position: absolute;
   display: block;
   content: '';
+  top: 0.25rem;
+  left: 0.25rem;
+  height: 0.5rem;
+  width: 0.5rem;
   border-radius: 50%;
+  background-color: #323232;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 <Radio>
@@ -280,17 +302,39 @@ exports[`<Radio /> when checked renders correctly 1`] = `
   position: relative;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
   border-radius: 50%;
   z-index: 1;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
 }
 
 input:checked + .c2:after {
   position: absolute;
   display: block;
   content: '';
+  top: 0.25rem;
+  left: 0.25rem;
+  height: 0.5rem;
+  width: 0.5rem;
   border-radius: 50%;
+  background-color: #323232;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 <Radio
@@ -543,17 +587,39 @@ exports[`<Radio /> when disabled renders correctly 1`] = `
   position: relative;
   vertical-align: middle;
   margin-bottom: 0.125rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
   width: 1.25rem;
+  background-color: #FFFFFF;
+  border: 2px solid;
+  border-color: #DADADA;
   border-radius: 50%;
   z-index: 1;
+}
+
+input:checked + .c2,
+input:focus + .c2,
+input:hover + .c2 {
+  border-color: #8DE2E0;
+  -webkit-transition: 200ms ease-in;
+  transition: 200ms ease-in;
 }
 
 input:checked + .c2:after {
   position: absolute;
   display: block;
   content: '';
+  top: 0.25rem;
+  left: 0.25rem;
+  height: 0.5rem;
+  width: 0.5rem;
   border-radius: 50%;
+  background-color: #323232;
+}
+
+input:disabled + .c2 {
+  background-color: #DADADA;
+  border-color: #DADADA;
 }
 
 <Radio

--- a/packages/test-utils/src/mountWithTheme.js
+++ b/packages/test-utils/src/mountWithTheme.js
@@ -1,8 +1,14 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { ThemeProvider } from 'styled-components';
 
 export default (tree, theme) => {
-  const context = mount(<ThemeProvider theme={theme} />).instance().getChildContext();
-  return mount(tree, { context });
+  const context = shallow(<ThemeProvider theme={theme} />)
+    .instance()
+    .getChildContext();
+
+  return mount(tree, {
+    context,
+    childContextTypes: ThemeProvider.childContextTypes,
+  });
 };

--- a/packages/test-utils/src/shallowWithTheme.js
+++ b/packages/test-utils/src/shallowWithTheme.js
@@ -3,6 +3,12 @@ import { shallow } from 'enzyme';
 import { ThemeProvider } from 'styled-components';
 
 export default (tree, theme) => {
-  const context = shallow(<ThemeProvider theme={theme} />).instance().getChildContext();
-  return shallow(tree, { context });
+  const context = shallow(<ThemeProvider theme={theme} />)
+    .instance()
+    .getChildContext();
+
+  return shallow(tree, {
+    context,
+    childContextTypes: ThemeProvider.childContextTypes,
+  });
 };

--- a/packages/test-utils/src/shallowWithTheme.js
+++ b/packages/test-utils/src/shallowWithTheme.js
@@ -7,8 +7,5 @@ export default (tree, theme) => {
     .instance()
     .getChildContext();
 
-  return shallow(tree, {
-    context,
-    childContextTypes: ThemeProvider.childContextTypes,
-  });
+  return shallow(tree, { context });
 };


### PR DESCRIPTION
**What**

With our current setup, the theme is only passed to the top level component. When you `mount` a component or `dive` the child component theme values are undefined.

So far this has not caused any issues. We ran into an issue where a `styled-system` function threw an error because the theme value undefined.

**Fix**

Found the fix on this [thread](https://github.com/styled-components/jest-styled-components/issues/106) and they have update their docs recently.

Solution is to pass this down when mounting `childContextTypes: ThemeProvider.childContextTypes`