### PR TITLE
refactor: add generic colour names

### DIFF
--- a/packages/components/src/StarRating/StarRating.js
+++ b/packages/components/src/StarRating/StarRating.js
@@ -18,7 +18,7 @@ const renderRating = ({ ratingType, rating, size }) => {
     ratingItems.push(<Icon
       name={iconType(rating, index, ratingType)}
       key={index}
-      color="starRating"
+      color="brightSun"
       size={size}
     />);
   });

--- a/packages/components/src/StarRating/__snapshots__/StarRating.test.js.snap
+++ b/packages/components/src/StarRating/__snapshots__/StarRating.test.js.snap
@@ -7,31 +7,31 @@ exports[`<StarRating /> renders correctly 1`] = `
   title="1 out of 5 rating"
 >
   <Icon
-    color="starRating"
+    color="brightSun"
     key="0"
     name="circle"
     size="16"
   />
   <Icon
-    color="starRating"
+    color="brightSun"
     key="1"
     name="circleBorder"
     size="16"
   />
   <Icon
-    color="starRating"
+    color="brightSun"
     key="2"
     name="circleBorder"
     size="16"
   />
   <Icon
-    color="starRating"
+    color="brightSun"
     key="3"
     name="circleBorder"
     size="16"
   />
   <Icon
-    color="starRating"
+    color="brightSun"
     key="4"
     name="circleBorder"
     size="16"

--- a/packages/themes/src/ThemeProvider.js
+++ b/packages/themes/src/ThemeProvider.js
@@ -6,13 +6,13 @@ const ThemeProvider = ({ theme, ...otherProps }) => {
     body {
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-    
+
       font-family: ${theme.fontFamily};
       font-size: ${theme.fontSizes.base};
       line-height: ${theme.lineHeights.normal};
-      color: ${theme.colors.text};
+      color: ${theme.colors.greys.charcoal};
     }
-  
+
     *, *:before, *:after {
       box-sizing: border-box;
     }

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -34,7 +34,6 @@ const colors = {
     successBackground: '#DEF2DE',
   },
   greys,
-  text: '#323232',
   ...miscellaneousColours,
 };
 

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -1,13 +1,28 @@
 import { rem } from 'polished';
 import range from 'lodash/range';
 
+const brand = {
+  primary: '#E40000',
+  secondary: '#8DE2E0',
+  tertiary: '#D20000',
+  quaternary: '#F9F3E9',
+}
+
+const greys = {
+  charcoal: '#323232',
+  steel: '#666666',
+  alto: '#DADADA',
+  porcelain: '#F4F5F6',
+  dusty: '#999999',
+}
+
+const miscellaneousColours = {
+  white: '#FFFFFF',
+  brightSun: '#FBCB3B',
+};
+
 const colors = {
-  brand: {
-    primary: '#E40000',
-    secondary: '#8DE2E0',
-    tertiary: '#D20000',
-    quaternary: '#F9F3E9',
-  },
+  brand,
   ui: {
     link: '#E00E00',
     linkHover: '#870000',
@@ -18,17 +33,9 @@ const colors = {
     success: '#35A509',
     successBackground: '#DEF2DE',
   },
-  greys: {
-    charcoal: '#323232',
-    steel: '#666666',
-    alto: '#DADADA',
-    porcelain: '#F4F5F6',
-    dusty: '#999999',
-  },
-
-  white: '#FFFFFF',
+  greys,
   text: '#323232',
-  starRating: '#FBCB3B',
+  ...miscellaneousColours,
 };
 
 const fontFamily = 'QantasCiutadella, sans-serif';

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -16,25 +16,35 @@ const greys = {
   dusty: '#999999',
 }
 
-const miscellaneousColours = {
+const assortedColours = {
   white: '#FFFFFF',
   brightSun: '#FBCB3B',
+  red: '#E00E00',
+  maroon: '#870000',
+  riptide: '#8DE2E0',
+  blackSqueeze: '#E7F7F7',
+  christine: '#ED710B',
+  doublePearlLusta: '#FCEBCD',
+  christi: '#35A509',
+  peppermint: '#DEF2DE',
+};
+
+const ui = {
+  link: assortedColours.red,
+  linkHover: assortedColours.maroon,
+  info: assortedColours.riptide,
+  infoBackground: assortedColours.blackSqueeze,
+  error: assortedColours.christine,
+  errorBackground: assortedColours.doublePearlLusta,
+  success: assortedColours.christi,
+  successBackground: assortedColours.peppermint,
 };
 
 const colors = {
   brand,
-  ui: {
-    link: '#E00E00',
-    linkHover: '#870000',
-    info: '#8DE2E0',
-    infoBackground: '#E7F7F7',
-    error: '#ED710B',
-    errorBackground: '#FCEBCD',
-    success: '#35A509',
-    successBackground: '#DEF2DE',
-  },
+  ui,
   greys,
-  ...miscellaneousColours,
+  ...assortedColours,
 };
 
 const fontFamily = 'QantasCiutadella, sans-serif';

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -14,30 +14,30 @@ const greys = {
   alto: '#DADADA',
   porcelain: '#F4F5F6',
   dusty: '#999999',
-}
+};
 
 const assortedColours = {
   white: '#FFFFFF',
   brightSun: '#FBCB3B',
   red: '#E00E00',
   maroon: '#870000',
-  riptide: '#8DE2E0',
-  blackSqueeze: '#E7F7F7',
-  christine: '#ED710B',
-  doublePearlLusta: '#FCEBCD',
-  christi: '#35A509',
-  peppermint: '#DEF2DE',
+  blue: '#8DE2E0',
+  lightBlue: '#E7F7F7',
+  orange: '#ED710B',
+  lightOrange: '#FCEBCD',
+  green: '#35A509',
+  lightGreen: '#DEF2DE',
 };
 
 const ui = {
   link: assortedColours.red,
   linkHover: assortedColours.maroon,
-  info: assortedColours.riptide,
-  infoBackground: assortedColours.blackSqueeze,
-  error: assortedColours.christine,
-  errorBackground: assortedColours.doublePearlLusta,
-  success: assortedColours.christi,
-  successBackground: assortedColours.peppermint,
+  info: assortedColours.blue,
+  infoBackground: assortedColours.lightBlue,
+  error: assortedColours.orange,
+  errorBackground: assortedColours.lightOrange,
+  success: assortedColours.green,
+  successBackground: assortedColours.lightGreen,
 };
 
 const colors = {

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -16,7 +16,7 @@ const greys = {
   dusty: '#999999',
 };
 
-const assortedColours = {
+const namedColors = {
   white: '#FFFFFF',
   brightSun: '#FBCB3B',
   red: '#E00E00',
@@ -30,21 +30,21 @@ const assortedColours = {
 };
 
 const ui = {
-  link: assortedColours.red,
-  linkHover: assortedColours.maroon,
-  info: assortedColours.blue,
-  infoBackground: assortedColours.lightBlue,
-  error: assortedColours.orange,
-  errorBackground: assortedColours.lightOrange,
-  success: assortedColours.green,
-  successBackground: assortedColours.lightGreen,
+  link: namedColors.red,
+  linkHover: namedColors.maroon,
+  info: namedColors.blue,
+  infoBackground: namedColors.lightBlue,
+  error: namedColors.orange,
+  errorBackground: namedColors.lightOrange,
+  success: namedColors.green,
+  successBackground: namedColors.lightGreen,
 };
 
 const colors = {
   brand,
   ui,
   greys,
-  ...assortedColours,
+  ...namedColors,
 };
 
 const fontFamily = 'QantasCiutadella, sans-serif';

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -6,7 +6,7 @@ const brand = {
   secondary: '#8DE2E0',
   tertiary: '#D20000',
   quaternary: '#F9F3E9',
-}
+};
 
 const greys = {
   charcoal: '#323232',


### PR DESCRIPTION
closes #138 

Add generic colour names for the rest of the colours. 
Not all of them are using the colour naming tool. For instance the colour naming tool would of given us the name `blackSqueeze` for `lightBlue`.
