### PR TITLE
Remove the border from the focus state of the DateRangePicker day

### DIFF
--- a/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
+++ b/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
@@ -103,9 +103,6 @@ const Button = NakedButton.extend`
         background-color: transparent;
         border-color: ${themeGet('colors.brand.secondary')};
       }
-      &:focus {
-        border-color: ${themeGet('colors.lightBlue')};
-      }
     `};
 
   ${props =>


### PR DESCRIPTION
From: 

![image](https://user-images.githubusercontent.com/661756/44636284-61a03500-a9ee-11e8-9e95-8fb71acb1917.png)


To: 

![image](https://user-images.githubusercontent.com/661756/44636321-85fc1180-a9ee-11e8-9acb-858869e7e1f9.png)
