### PR TITLE
fix: add focus style to calendar day

### DIFF
--- a/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
+++ b/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
@@ -74,7 +74,8 @@ const Button = NakedButton.extend`
     css`
       background-color: ${themeGet('colors.lightBlue')};
 
-      &:hover {
+      &:hover,
+      &:focus {
         border-color: ${themeGet('colors.brand.secondary')};
         background-color: ${themeGet('colors.white')};;
       }


### PR DESCRIPTION
With the recent calendar work we have lost the focus style.
This adds the same focus style to the selected calendar day.

@KamalMicheal Check that this ok with your date range calendar. Right now you are missing a focus style as well.