### PR TITLE
fix: DateRangePicker offset bug and props refactor

### DIFF
--- a/packages/components/src/DatePicker/DateRangePicker.README.md
+++ b/packages/components/src/DatePicker/DateRangePicker.README.md
@@ -20,23 +20,31 @@ export default (
 );
 ```
 
+## Notes
+
+This component holds internal state for the `startDate`, `endDate`, `isSettingStartDate` and `isSettingEndDate`. You will only
+be able to set this state via props on the initial render. If you want to update these values from a parent component, you
+should pass a new `key` to this component to force a new component to be created with the new prop values. For more information
+see: [Fully uncontrolled component with a key](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key)
+
 ## Properties
 
-| Name                       | Description                                      | Type       | Default | Required? |
-|----------------------------|--------------------------------------------------|------------|---------|-----------|
-| `monthsToDisplay`          | Number of months to display                      | `number`   | 1       | -         |
-| `stacked`                  | Stack the calendar months vertically             | `boolean`  | false   | -         |
-| `monthNames`               | Month names                                      | `array`    | -       | -         |
-| `weekdayNames`             | Weekday names                                    | `array`    | -       | -         |
-| `disabledDates`            | Dates which will be disabled                     | `array`    | []      | -         |
-| `interactiveDisabledDates` | Disabled dates will be clickable                 | `boolean`  | false   | -         |
-| `startDate`                | Start date of the range                          | `date`     | -       | -         |
-| `endDate`                  | End date of the range                            | `date`     | -       | -         |
-| `setStartDate`             | Change the start date of the range               | `boolean`  | false   | -         |
-| `setEndDate`               | Change the end date of the range                 | `boolean`  | false   | -         |
-| `onRangeSelected`          | Callback function when the range is selected     | `function` | -       | true      |
-| `onChangeStartDate`        | Callback function when the start date is chnaged | `function` | -       | false     |
-| `onChangeEndDate`          | Callback function when the end date is chnaged   | `function` | -       | false     |
+| Name                       | Description                                      | Type       | Default     | Required? |
+|----------------------------|--------------------------------------------------|------------|-------------|-----------|
+| `monthsToDisplay`          | Number of months to display                      | `number`   | 1           | -         |
+| `firstDayOfWeek`           | First day of the week, Defaults to 0 (Monday)    | `number`   | 1           | -         |
+| `stacked`                  | Stack the calendar months vertically             | `boolean`  | false       | -         |
+| `minDate`                  | Used to calculate the minimum month to render.   | `date`     | yesterday   | -         |
+| `monthNames`               | Month names                                      | `array`    | -           | -         |
+| `weekdayNames`             | Weekday names                                    | `array`    | -           | -         |
+| `disabledDates`            | Dates which will be disabled                     | `array`    | []          | -         |
+| `interactiveDisabledDates` | Disabled dates will be clickable                 | `boolean`  | false       | -         |
+| `initialStartDate`         | Start date of the range on first render          | `date`     | -           | -         |
+| `initialEndDate`           | End date of the range initialEndDate             | `date`     | -           | -         |
+| `isSettingStartDate`       | Change the start date of the range               | `boolean`  | false       | -         |
+| `isSettingEndDate`         | Change the end date of the range                 | `boolean`  | false       | -         |
+| `onRangeSelected`          | Callback function when the range is selected     | `function` | -           | -         |
+| `onChangeDates`            | Callback function when a date is changed         | `function` | -           | -         |
 
 ## Customization
 

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import Dayzed from 'dayzed';
 import { subDays, differenceInCalendarMonths, startOfDay, endOfDay, isSameDay } from 'date-fns';
 import throttle from 'lodash/throttle';
@@ -11,6 +12,10 @@ import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
 
 const NOOP = () => false;
+
+const Wrapper = styled(Box)`
+  position: relative;
+`;
 
 const calculateMonthOffset = (startDate = null, endDate = null) => {
   const today = new Date();
@@ -162,7 +167,7 @@ class DateRangePicker extends React.Component {
             if (!calendars.length) return null;
 
             return (
-              <Box onMouseLeave={this.onMouseLeaveOfCalendar}>
+              <Wrapper onMouseLeave={this.onMouseLeaveOfCalendar}>
                 <CalendarNav
                   prevProps={getBackProps({ calendars })}
                   nextProps={getForwardProps({ calendars })}
@@ -187,7 +192,7 @@ class DateRangePicker extends React.Component {
                     />
                   ))}
                 </Flex>
-              </Box>
+              </Wrapper>
             );
           }}
       />

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,27 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Dayzed from 'dayzed';
-import { themeGet } from 'styled-system';
 import { subDays, isEqual } from 'date-fns';
 import throttle from 'lodash/throttle';
 
-import { Flex, Box, Input } from '../';
+import { Flex, Box } from '../';
 
 import isDateInRange from './lib/isDateInRange';
 import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
-
-const DateInput = Input.extend`
-  border: ${themeGet('borders.2')} ${themeGet('colors.greys.porcelain')};
-  color: transparent;
-  text-shadow: 0 0 0 ${themeGet('colors.greys.charcoal')};
-  border-color: ${props => ((props.highlight) ? themeGet('colors.brand.secondary') : themeGet('colors.greys.porcelain'))};
-`;
-
-DateInput.defaultProps = {
-  ...Input.defaultProps,
-  blacklist: [...Object.keys(Input.propTypes), 'highlight'],
-};
 
 class DateRangePicker extends React.Component {
   constructor(props) {
@@ -29,10 +16,10 @@ class DateRangePicker extends React.Component {
 
     this.state = {
       hoveredDate: null,
-      startDate: props.startDate,
-      endDate: props.endDate,
-      isSettingStartDate: props.setStartDate,
-      isSettingEndDate: props.setEndDate,
+      startDate: props.initialStartDate,
+      endDate: props.initialEndDate,
+      isSettingStartDate: props.isSettingStartDate,
+      isSettingEndDate: props.isSettingEndDate,
     };
   }
 
@@ -200,12 +187,12 @@ DateRangePicker.defaultProps = {
   monthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   weekdayNames: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
   interactiveDisabledDates: false,
-  startDate: null,
-  endDate: null,
+  initialStartDate: null,
+  initialEndDate: null,
   onChangeStartDate: null,
   onChangeEndDate: null,
-  setStartDate: false,
-  setEndDate: false,
+  isSettingStartDate: false,
+  isSettingEndDate: false,
 };
 
 DateRangePicker.propTypes = {
@@ -217,13 +204,13 @@ DateRangePicker.propTypes = {
   interactiveDisabledDates: PropTypes.bool,
   monthNames: PropTypes.arrayOf(PropTypes.string),
   weekdayNames: PropTypes.arrayOf(PropTypes.string),
-  startDate: PropTypes.instanceOf(Date),
-  endDate: PropTypes.instanceOf(Date),
+  initialStartDate: PropTypes.instanceOf(Date),
+  initialEndDate: PropTypes.instanceOf(Date),
   onChangeStartDate: PropTypes.func,
   onChangeEndDate: PropTypes.func,
   onRangeSelected: PropTypes.func.isRequired,
-  setStartDate: PropTypes.bool,
-  setEndDate: PropTypes.bool,
+  isSettingStartDate: PropTypes.bool,
+  isSettingEndDate: PropTypes.bool,
 };
 
 export default DateRangePicker;

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import Dayzed from 'dayzed';
 import { subDays, differenceInCalendarMonths, startOfDay, endOfDay, isSameDay } from 'date-fns';
 import throttle from 'lodash/throttle';
@@ -12,10 +11,6 @@ import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
 
 const NOOP = () => false;
-
-const Wrapper = styled(Box)`
-  position: relative;
-`;
 
 const calcuateMonthOffsetFromToday = (focusDate) => {
   const today = new Date();
@@ -166,7 +161,7 @@ class DateRangePicker extends React.Component {
             if (!calendars.length) return null;
 
             return (
-              <Wrapper onMouseLeave={this.onMouseLeaveOfCalendar}>
+              <Box onMouseLeave={this.onMouseLeaveOfCalendar} position="relative">
                 <CalendarNav
                   prevProps={getBackProps({ calendars })}
                   nextProps={getForwardProps({ calendars })}
@@ -191,7 +186,7 @@ class DateRangePicker extends React.Component {
                     />
                   ))}
                 </Flex>
-              </Wrapper>
+              </Box>
             );
           }}
       />

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -17,11 +17,9 @@ const Wrapper = styled(Box)`
   position: relative;
 `;
 
-const calculateMonthOffset = (startDate = null, endDate = null) => {
+const calcuateMonthOffsetFromToday = (focusDate) => {
   const today = new Date();
-  const displayDate = startDate || endDate || today;
-  const offset = differenceInCalendarMonths(displayDate, today);
-  return offset;
+  return differenceInCalendarMonths(focusDate, today);
 };
 
 class DateRangePicker extends React.Component {
@@ -31,10 +29,11 @@ class DateRangePicker extends React.Component {
     const { initialStartDate, initialEndDate } = this.props;
     const startDate = initialStartDate ? startOfDay(initialStartDate) : null;
     const endDate = initialEndDate ? endOfDay(initialEndDate) : null;
+    const focusDate = startDate || endDate || new Date();
 
     this.state = {
       hoveredDate: null,
-      offset: calculateMonthOffset(startDate, endDate),
+      offset: calcuateMonthOffsetFromToday(focusDate),
       isSettingStartDate: props.isSettingStartDate,
       isSettingEndDate: props.isSettingEndDate,
       startDate,

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -67,9 +67,10 @@ class DateRangePicker extends React.Component {
 
   notifyRangeSelection = () => {
     const { startDate, endDate } = this.state;
+    const { onRangeSelected } = this.props;
 
-    if (startDate && endDate) {
-      this.props.onRangeSelected({ startDate, endDate });
+    if (startDate && endDate && onRangeSelected) {
+      onRangeSelected({ startDate, endDate });
     }
   }
 
@@ -191,6 +192,7 @@ DateRangePicker.defaultProps = {
   initialEndDate: null,
   onChangeStartDate: null,
   onChangeEndDate: null,
+  onRangeSelected: null,
   isSettingStartDate: false,
   isSettingEndDate: false,
 };
@@ -208,7 +210,7 @@ DateRangePicker.propTypes = {
   initialEndDate: PropTypes.instanceOf(Date),
   onChangeStartDate: PropTypes.func,
   onChangeEndDate: PropTypes.func,
-  onRangeSelected: PropTypes.func.isRequired,
+  onRangeSelected: PropTypes.func,
   isSettingStartDate: PropTypes.bool,
   isSettingEndDate: PropTypes.bool,
 };

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Dayzed from 'dayzed';
-import { subDays, isEqual } from 'date-fns';
+import { subDays, isEqual, differenceInCalendarMonths } from 'date-fns';
 import throttle from 'lodash/throttle';
 
 import { Flex, Box } from '../';
@@ -10,12 +10,20 @@ import isDateInRange from './lib/isDateInRange';
 import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
 
+const calculateMonthOffset = (startDate = null, endDate = null) => {
+  const today = new Date();
+  const displayDate = startDate || endDate || today;
+  const offset = differenceInCalendarMonths(displayDate, today);
+  return offset;
+};
+
 class DateRangePicker extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
       hoveredDate: null,
+      offset: calculateMonthOffset(props.initialStartDate, props.initialEndDate),
       startDate: props.initialStartDate,
       endDate: props.initialEndDate,
       isSettingStartDate: props.isSettingStartDate,
@@ -36,6 +44,8 @@ class DateRangePicker extends React.Component {
       onChangeEndDate(endDate);
     }
   }
+
+  onOffsetChanged = offset => this.setState({ offset });
 
   onMouseLeaveOfCalendar = () => this.setState({ hoveredDate: null });
 
@@ -128,15 +138,18 @@ class DateRangePicker extends React.Component {
       interactiveDisabledDates,
       ...rest
     } = this.props;
-
-    const selectedDates = [this.state.startDate, this.state.endDate];
+    const { startDate, endDate, offset } = this.state;
+    const selectedDates = [startDate, endDate];
 
     return (
       <Dayzed
         {...rest}
         selected={selectedDates}
+        date={new Date()}
+        offset={offset}
         monthsToDisplay={monthsToDisplay}
         onDateSelected={this.onDateSelected}
+        onOffsetChanged={this.onOffsetChanged}
         render={({
             calendars,
             getBackProps,

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Dayzed from 'dayzed';
-import { subDays, isEqual, differenceInCalendarMonths, startOfDay, endOfDay } from 'date-fns';
+import { subDays, differenceInCalendarMonths, startOfDay, endOfDay, isSameDay } from 'date-fns';
 import throttle from 'lodash/throttle';
 
 import { Flex, Box } from '../';
@@ -9,6 +9,8 @@ import { Flex, Box } from '../';
 import isDateInRange from './lib/isDateInRange';
 import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
+
+const NOOP = () => false;
 
 const calculateMonthOffset = (startDate = null, endDate = null) => {
   const today = new Date();
@@ -38,14 +40,11 @@ class DateRangePicker extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const { startDate, endDate } = this.state;
     const { startDate: prevStartDate, endDate: prevEndDate } = prevState;
-    const { onChangeStartDate, onChangeEndDate } = this.props;
+    const startDateDidUpdate = !isSameDay(startDate, prevStartDate);
+    const endDateDidUpdate = !isSameDay(endDate, prevEndDate);
 
-    if (!isEqual(startDate, prevStartDate) && onChangeStartDate) {
-      onChangeStartDate(startDate);
-    }
-
-    if (!isEqual(endDate, prevEndDate) && onChangeEndDate) {
-      onChangeEndDate(endDate);
+    if (startDateDidUpdate || endDateDidUpdate) {
+      this.props.onChangeDates({ startDate, endDate });
     }
   }
 
@@ -209,9 +208,10 @@ DateRangePicker.defaultProps = {
   initialEndDate: null,
   onChangeStartDate: null,
   onChangeEndDate: null,
-  onRangeSelected: null,
   isSettingStartDate: false,
   isSettingEndDate: false,
+  onRangeSelected: NOOP,
+  onChangeDates: NOOP,
 };
 
 DateRangePicker.propTypes = {
@@ -225,11 +225,10 @@ DateRangePicker.propTypes = {
   weekdayNames: PropTypes.arrayOf(PropTypes.string),
   initialStartDate: PropTypes.instanceOf(Date),
   initialEndDate: PropTypes.instanceOf(Date),
-  onChangeStartDate: PropTypes.func,
-  onChangeEndDate: PropTypes.func,
-  onRangeSelected: PropTypes.func,
   isSettingStartDate: PropTypes.bool,
   isSettingEndDate: PropTypes.bool,
+  onRangeSelected: PropTypes.func,
+  onChangeDates: PropTypes.func,
 };
 
 export default DateRangePicker;

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Dayzed from 'dayzed';
-import { subDays, isEqual, differenceInCalendarMonths } from 'date-fns';
+import { subDays, isEqual, differenceInCalendarMonths, startOfDay, endOfDay } from 'date-fns';
 import throttle from 'lodash/throttle';
 
 import { Flex, Box } from '../';
@@ -21,13 +21,17 @@ class DateRangePicker extends React.Component {
   constructor(props) {
     super(props);
 
+    const { initialStartDate, initialEndDate } = this.props;
+    const startDate = initialStartDate ? startOfDay(initialStartDate) : null;
+    const endDate = initialEndDate ? endOfDay(initialEndDate) : null;
+
     this.state = {
       hoveredDate: null,
-      offset: calculateMonthOffset(props.initialStartDate, props.initialEndDate),
-      startDate: props.initialStartDate,
-      endDate: props.initialEndDate,
+      offset: calculateMonthOffset(startDate, endDate),
       isSettingStartDate: props.isSettingStartDate,
       isSettingEndDate: props.isSettingEndDate,
+      startDate,
+      endDate,
     };
   }
 

--- a/packages/components/src/DatePicker/DateRangePicker.story.js
+++ b/packages/components/src/DatePicker/DateRangePicker.story.js
@@ -17,15 +17,12 @@ storiesOf('Components|DateRangePicker', module)
   .addDecorator(withDocs(README))
   .add('default', () => (
     <DateRangePicker
-      monthsToDisplay={number('Months to display', 1)}
-      minDate={date}
-      startDate={addDays(date, 3)}
-      endDate={addDays(date, 7)}
+      monthsToDisplay={number('Months to display', 2)}
       stacked={boolean('Stacked', false)}
-      setStartDate={boolean('Change start date', false)}
-      setEndDate={boolean('Change end date', false)}
-      onRangeSelected={console.log} // eslint-disable-line no-console
-      onChangeStartDate={console.log} // eslint-disable-line no-console
-      onChangeEndDate={console.log} // eslint-disable-line no-console
+      minDate={date}
+      initialStartDate={addDays(date, 3)}
+      initialEndDate={addDays(date, 7)}
+      isSettingStartDate={false}
+      isSettingEndDate={false}
     />
   ));

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -20,10 +20,10 @@ describe('<DateRangePicker />', () => {
   };
 
   const setup = (args = {}) => {
-    props.startDate = args.startDate || null;
-    props.endDate = args.endDate || null;
-    props.setStartDate = args.setStartDate || false;
-    props.setEndDate = args.setEndDate || false;
+    props.initialStartDate = args.initialStartDate || null;
+    props.initialEndDate = args.initialEndDate || null;
+    props.isSettingStartDate = args.isSettingStartDate || false;
+    props.isSettingEndDate = args.isSettingEndDate || false;
 
     wrapper = mountWithTheme(<DateRangePicker {...props} />, theme);
   };
@@ -60,11 +60,11 @@ describe('<DateRangePicker />', () => {
   });
 
   describe('preselected range', () => {
-    const startDate = parse('2018-07-15');
-    const endDate = parse('2018-07-20');
+    const initialStartDate = parse('2018-07-15');
+    const initialEndDate = parse('2018-07-20');
 
     beforeEach(() => {
-      setup({ startDate, endDate });
+      setup({ initialStartDate, initialEndDate });
     });
 
     it('highlights dates in range', () => {
@@ -84,13 +84,13 @@ describe('<DateRangePicker />', () => {
   });
 
   describe('when only start date is set', () => {
-    const startDate = parse('2018-07-15');
+    const initialStartDate = parse('2018-07-15');
 
-    describe('with setStartDate is false', () => {
-      const setStartDate = false;
+    describe('with isSettingStartDate is false', () => {
+      const isSettingStartDate = false;
 
       beforeEach(() => {
-        setup({ startDate, setStartDate });
+        setup({ initialStartDate, isSettingStartDate });
       });
 
       it('selects start date', () => {
@@ -192,11 +192,11 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    describe('with setStartDate is true', () => {
-      const setStartDate = true;
+    describe('with isSettingStartDate is true', () => {
+      const isSettingStartDate = true;
 
       beforeEach(() => {
-        setup({ startDate, setStartDate });
+        setup({ initialStartDate, isSettingStartDate });
       });
 
       it('selects start date', () => {
@@ -298,11 +298,11 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    describe('with setEndDate is true', () => {
-      const setEndDate = true;
+    describe('with isSettingEndDate is true', () => {
+      const isSettingEndDate = true;
 
       beforeEach(() => {
-        setup({ startDate, setEndDate });
+        setup({ initialStartDate, isSettingEndDate });
       });
 
       it('selects start date', () => {
@@ -406,14 +406,14 @@ describe('<DateRangePicker />', () => {
   });
 
   describe('when start date & end date are set', () => {
-    const startDate = parse('2018-07-15');
-    const endDate = parse('2018-07-20');
+    const initialStartDate = parse('2018-07-15');
+    const initialEndDate = parse('2018-07-20');
 
-    describe('with setStartDate is true', () => {
-      const setStartDate = true;
+    describe('with isSettingStartDate is true', () => {
+      const isSettingStartDate = true;
 
       beforeEach(() => {
-        setup({ startDate, endDate, setStartDate });
+        setup({ initialStartDate, initialEndDate, isSettingStartDate });
       });
 
       describe('when click on a date < endDate', () => {
@@ -465,11 +465,11 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    describe('with setEndDate is true', () => {
-      const setEndDate = true;
+    describe('with isSettingEndDate is true', () => {
+      const isSettingEndDate = true;
 
       beforeEach(() => {
-        setup({ startDate, endDate, setEndDate });
+        setup({ initialStartDate, initialEndDate, isSettingEndDate });
       });
 
       describe('when click on a date > startDate', () => {
@@ -521,11 +521,11 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    describe('with setStartDate is false and setEndDate is false', () => {
+    describe('with isSettingStartDate is false and isSettingEndDate is false', () => {
       let newClickedDate;
 
       beforeEach(() => {
-        setup({ startDate, endDate });
+        setup({ initialStartDate, initialEndDate });
 
         wrapper.find('CalendarDay').at(22).find('button').simulate('click');
         wrapper.update();

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -27,10 +27,37 @@ describe('<DateRangePicker />', () => {
     wrapper = mountWithTheme(<DateRangePicker {...props} />, theme);
   };
 
-  describe('disabledDates', () => {
-    beforeEach(() => {
-      setup();
+  describe('when initial dates are passed in', () => {
+    describe('and those dates are in the same month as the minDate', () => {
+      const initialStartDate = new Date('2018-07-15');
+      const initialEndDate = new Date('2018-07-20');
+
+      beforeEach(() => setup({ initialStartDate, initialEndDate }));
+
+      it('displays the correct month', () => {
+        const MonthWrapper = wrapper.find('MonthWrapper');
+        expect(MonthWrapper.find('Text').first().text()).toEqual('Jul 2018');
+      });
     });
+
+    describe('and those dates are in advance of the minDate', () => {
+      const initialStartDate = new Date('2018-11-15');
+      const initialEndDate = new Date('2018-11-20');
+
+      beforeEach(() => setup({ initialStartDate, initialEndDate }));
+
+      it('displays the correct month', () => {
+        const MonthWrapper = wrapper.find('MonthWrapper');
+        expect(MonthWrapper.find('Text').first().text()).toEqual('Nov 2018');
+      });
+    });
+  });
+
+  describe('disabledDates', () => {
+    const initialStartDate = new Date('2018-07-15');
+    const initialEndDate = new Date('2018-07-20');
+
+    beforeEach(() => setup({ initialStartDate, initialEndDate }));
 
     it('disables dates in disabledDates array', () => {
       const date4 = wrapper.find('CalendarDay').at(3);

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -6,6 +6,9 @@ import { mountWithTheme } from '@roo-ui/test-utils';
 
 import DateRangePicker from './DateRangePicker';
 
+const rangeInclusive = (start = 0, end = 0) => range(start, end + 1);
+const getDayOfMonth = (wrapper, dayOfMonth) => wrapper.find('CalendarDay').at(dayOfMonth - 1);
+
 describe('<DateRangePicker />', () => {
   let wrapper;
 
@@ -94,9 +97,9 @@ describe('<DateRangePicker />', () => {
     });
 
     it('highlights dates in range', () => {
-      range(15, 18).forEach((index) => {
-        const date = wrapper.find('CalendarDay').at(index);
-        expect(date.props()).toEqual(expect.objectContaining({ highlighted: true }));
+      rangeInclusive(15, 20).forEach((index) => {
+        const day = getDayOfMonth(wrapper, index);
+        expect(day.props()).toEqual(expect.objectContaining({ highlighted: true }));
       });
     });
 

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -11,7 +11,6 @@ describe('<DateRangePicker />', () => {
 
   const props = {
     minDate: parse('2018-07-01'),
-    maxDate: parse('2018-07-31'),
     onRangeSelected: jest.fn,
     monthsToDisplay: 1,
     stacked: true,

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -12,7 +12,7 @@ const getDayOfMonth = (wrapper, dayOfMonth) => wrapper.find('CalendarDay').at(da
 describe('<DateRangePicker />', () => {
   let wrapper;
 
-  const props = {
+  const defaultProps = {
     minDate: parse('2018-07-01'),
     onRangeSelected: jest.fn,
     monthsToDisplay: 1,
@@ -22,11 +22,7 @@ describe('<DateRangePicker />', () => {
   };
 
   const setup = (args = {}) => {
-    props.initialStartDate = args.initialStartDate || null;
-    props.initialEndDate = args.initialEndDate || null;
-    props.isSettingStartDate = args.isSettingStartDate || false;
-    props.isSettingEndDate = args.isSettingEndDate || false;
-
+    const props = { ...defaultProps, ...args };
     wrapper = mountWithTheme(<DateRangePicker {...props} />, theme);
   };
 
@@ -109,6 +105,40 @@ describe('<DateRangePicker />', () => {
 
       expect(day15.props()).toEqual(expect.objectContaining({ selected: true }));
       expect(day20.props()).toEqual(expect.objectContaining({ selected: true }));
+    });
+  });
+
+  describe('callbacks', () => {
+    let callback;
+
+    describe('when selecting three sequential days', () => {
+      beforeEach(() => {
+        callback = jest.fn();
+        setup({ onChangeDates: callback });
+        getDayOfMonth(wrapper, 1).find('button').simulate('click');
+        getDayOfMonth(wrapper, 2).find('button').simulate('click');
+        getDayOfMonth(wrapper, 3).find('button').simulate('click');
+        wrapper.update();
+      });
+
+      it('calls the callback three times', () => {
+        expect(callback).toHaveBeenCalledTimes(3);
+      });
+
+      it('calls the first callback with only the correct start date', () => {
+        expect(callback.mock.calls[0][0].startDate.toLocaleString()).toEqual('2018-9-1 00:00:00');
+        expect(callback.mock.calls[0][0].endDate).toBeNull();
+      });
+
+      it('calls the second callback with the correct start and end dates', () => {
+        expect(callback.mock.calls[1][0].startDate.toLocaleString()).toEqual('2018-9-1 00:00:00');
+        expect(callback.mock.calls[1][0].endDate.toLocaleString()).toEqual('2018-9-2 00:00:00');
+      });
+
+      it('calls the third callback with the correct start date and resets the end date', () => {
+        expect(callback.mock.calls[2][0].startDate.toLocaleString()).toEqual('2018-9-3 00:00:00');
+        expect(callback.mock.calls[2][0].endDate).toBeNull();
+      });
     });
   });
 

--- a/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
+++ b/packages/components/src/DatePicker/components/CalendarDay/CalendarDay.js
@@ -11,9 +11,7 @@ const DayWrapper = Box.extend`
   width: calc(100% / 7);
   margin: 0 -1px -1px 0;
   position: relative;
-  ${props => css`
-    border: ${themeGet('borders.1')} ${darken(0.1, themeGet('colors.greys.alto')(props))};
-  `}
+  border: ${themeGet('borders.1')} transparent;
 
   &:after {
     content: "";

--- a/packages/components/src/DatePicker/components/CalendarDay/__snapshots__/CalendarDay.test.js.snap
+++ b/packages/components/src/DatePicker/components/CalendarDay/__snapshots__/CalendarDay.test.js.snap
@@ -87,7 +87,7 @@ exports[`<CalendarEmptyDay /> renders correctly 1`] = `
   width: calc(100% / 7);
   margin: 0 -1px -1px 0;
   position: relative;
-  border: 1px solid #c1c1c1;
+  border: 1px solid transparent;
   border-color: transparent;
 }
 

--- a/packages/components/src/DatePicker/components/CalendarDays/CalendarDays.test.js
+++ b/packages/components/src/DatePicker/components/CalendarDays/CalendarDays.test.js
@@ -39,9 +39,8 @@ describe('<CalendarDays />', () => {
   };
 
   const setup = (params = {}) => {
-    props.isInRange = params.isInRange;
-    props.onMouseEnterOfDay = params.onMouseEnterOfDay;
-    wrapper = shallowWithTheme(<CalendarDays {...props} />, theme);
+    const newProps = { ...props, ...params };
+    wrapper = shallowWithTheme(<CalendarDays {...newProps} />, theme);
   };
 
   it('renders correctly', () => {
@@ -62,10 +61,24 @@ describe('<CalendarDays />', () => {
 
       describe('when isInRange is true', () => {
         it('props.highlighted is true', () => {
-          setup({
-            isInRange: () => true,
-          });
+          setup({ isInRange: () => true });
           expect(wrapper.find('CalendarDay').first().prop('highlighted')).toEqual(true);
+        });
+      });
+    });
+
+    describe('disabled', () => {
+      describe('when disabled dates are provided', () => {
+        beforeEach(() => setup({ disabledDates: [startDate, addDays(startDate, 1)] }));
+
+        it('provided dates are disabled', () => {
+          expect(wrapper.find('CalendarDay').at(0).prop('disabled')).toEqual(true);
+          expect(wrapper.find('CalendarDay').at(1).prop('disabled')).toEqual(true);
+        });
+
+        it('other dates are not disabled', () => {
+          expect(wrapper.find('CalendarDay').at(2).prop('disabled')).toEqual(false);
+          expect(wrapper.find('CalendarDay').at(3).prop('disabled')).toEqual(false);
         });
       });
     });

--- a/packages/components/src/DatePicker/components/CalendarMonth/CalendarMonth.js
+++ b/packages/components/src/DatePicker/components/CalendarMonth/CalendarMonth.js
@@ -23,6 +23,8 @@ const MonthWrapper = Box.extend`
     `};
 `;
 
+MonthWrapper.displayName = 'MonthWrapper';
+
 const CalendarMonth = ({
   monthsToDisplay, month, monthName, year, stacked, weekdayNames,
   weeks, getDateProps, disabledDates, interactiveDisabledDates,

--- a/packages/components/src/DatePicker/components/CalendarMonth/__snapshots__/CalendarMonth.test.js.snap
+++ b/packages/components/src/DatePicker/components/CalendarMonth/__snapshots__/CalendarMonth.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CalendarMonth /> renders correctly 1`] = `
-<Box
+<MonthWrapper
   blacklist={
     Array [
       "m",
@@ -160,5 +160,5 @@ exports[`<CalendarMonth /> renders correctly 1`] = `
     }
     year={2018}
   />
-</Box>
+</MonthWrapper>
 `;


### PR DESCRIPTION
The date range picker had a problem where if you have preselected dates, it would select them correctly but not update which month to show. You would always see the current month until nav controls were used to find the currently selected dates.

I've updated the props to better describe what they are doing and unified the seperate start and end callbacks into a single callback, to avoid a setState bug we were encountering.

I've also remove input that were not being used and updated the styling in places