### PR TITLE
fix: datepicker tests that rely on current date

### DIFF
--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -13,23 +13,18 @@ import CalendarMonth from './components/CalendarMonth';
 const NOOP = () => false;
 const throttled = throttle(10);
 
-const calcuateMonthOffsetFromToday = (focusDate) => {
-  const today = new Date();
-  return differenceInCalendarMonths(focusDate, today);
-};
-
 class DateRangePicker extends React.Component {
   constructor(props) {
     super(props);
 
-    const { initialStartDate, initialEndDate } = this.props;
+    const { initialStartDate, initialEndDate, initialDisplayDate } = this.props;
     const startDate = initialStartDate ? startOfDay(initialStartDate) : null;
     const endDate = initialEndDate ? endOfDay(initialEndDate) : null;
-    const focusDate = startDate || endDate || new Date();
+    const focusDate = startDate || endDate || initialDisplayDate;
 
     this.state = {
       hoveredDate: null,
-      offset: calcuateMonthOffsetFromToday(focusDate),
+      offset: differenceInCalendarMonths(focusDate, initialDisplayDate),
       isSettingStartDate: props.isSettingStartDate,
       isSettingEndDate: props.isSettingEndDate,
       startDate,
@@ -137,6 +132,7 @@ class DateRangePicker extends React.Component {
       stacked,
       disabledDates,
       interactiveDisabledDates,
+      initialDisplayDate,
       ...rest
     } = this.props;
     const { startDate, endDate, offset } = this.state;
@@ -146,7 +142,7 @@ class DateRangePicker extends React.Component {
       <Dayzed
         {...rest}
         selected={selectedDates}
-        date={new Date()}
+        date={initialDisplayDate}
         offset={offset}
         monthsToDisplay={monthsToDisplay}
         onDateSelected={this.onDateSelected}
@@ -204,6 +200,7 @@ DateRangePicker.defaultProps = {
   interactiveDisabledDates: false,
   initialStartDate: null,
   initialEndDate: null,
+  initialDisplayDate: new Date(),
   onChangeStartDate: null,
   onChangeEndDate: null,
   isSettingStartDate: false,
@@ -223,6 +220,7 @@ DateRangePicker.propTypes = {
   weekdayNames: PropTypes.arrayOf(PropTypes.string),
   initialStartDate: PropTypes.instanceOf(Date),
   initialEndDate: PropTypes.instanceOf(Date),
+  initialDisplayDate: PropTypes.instanceOf(Date),
   isSettingStartDate: PropTypes.bool,
   isSettingEndDate: PropTypes.bool,
   onRangeSelected: PropTypes.func,

--- a/packages/components/src/DatePicker/DateRangePicker.js
+++ b/packages/components/src/DatePicker/DateRangePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Dayzed from 'dayzed';
 import { subDays, differenceInCalendarMonths, startOfDay, endOfDay, isSameDay } from 'date-fns';
-import throttle from 'lodash/throttle';
+import throttle from 'lodash/fp/throttle';
 
 import { Flex, Box } from '../';
 
@@ -11,6 +11,7 @@ import CalendarNav from './components/CalendarNav';
 import CalendarMonth from './components/CalendarMonth';
 
 const NOOP = () => false;
+const throttled = throttle(10);
 
 const calcuateMonthOffsetFromToday = (focusDate) => {
   const today = new Date();
@@ -51,13 +52,11 @@ class DateRangePicker extends React.Component {
 
   onMouseLeaveOfCalendar = () => this.setState({ hoveredDate: null });
 
-  onMouseEnterOfDay = (hoveredDate) => {
-    throttle(() => {
-      if (this.state.startDate && !this.state.endDate) {
-        this.setState({ hoveredDate: hoveredDate.date });
-      }
-    }, 10)();
-  }
+  onMouseEnterOfDay = throttled((hoveredDate) => {
+    if (this.state.startDate && !this.state.endDate) {
+      this.setState({ hoveredDate: hoveredDate.date });
+    }
+  })
 
   onDateSelected = ({ selectable, date }) => {
     if (!selectable) return;

--- a/packages/components/src/DatePicker/DateRangePicker.test.js
+++ b/packages/components/src/DatePicker/DateRangePicker.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { parse } from 'date-fns';
+import { parse, format } from 'date-fns';
 import range from 'lodash/range';
 import { qantas as theme } from '@roo-ui/themes';
 import { mountWithTheme } from '@roo-ui/test-utils';
 
 import DateRangePicker from './DateRangePicker';
 
+const dateToString = date => format(date, 'YYYY-MM-DD');
 const rangeInclusive = (start = 0, end = 0) => range(start, end + 1);
 const getDayOfMonth = (wrapper, dayOfMonth) => wrapper.find('CalendarDay').at(dayOfMonth - 1);
 
@@ -114,7 +115,8 @@ describe('<DateRangePicker />', () => {
     describe('when selecting three sequential days', () => {
       beforeEach(() => {
         callback = jest.fn();
-        setup({ onChangeDates: callback });
+        const initialDisplayDate = parse('2018-07-15');
+        setup({ initialDisplayDate, onChangeDates: callback });
         getDayOfMonth(wrapper, 1).find('button').simulate('click');
         getDayOfMonth(wrapper, 2).find('button').simulate('click');
         getDayOfMonth(wrapper, 3).find('button').simulate('click');
@@ -126,17 +128,17 @@ describe('<DateRangePicker />', () => {
       });
 
       it('calls the first callback with only the correct start date', () => {
-        expect(callback.mock.calls[0][0].startDate.toLocaleString()).toEqual('2018-9-1 00:00:00');
+        expect(dateToString(callback.mock.calls[0][0].startDate)).toEqual('2018-07-01');
         expect(callback.mock.calls[0][0].endDate).toBeNull();
       });
 
       it('calls the second callback with the correct start and end dates', () => {
-        expect(callback.mock.calls[1][0].startDate.toLocaleString()).toEqual('2018-9-1 00:00:00');
-        expect(callback.mock.calls[1][0].endDate.toLocaleString()).toEqual('2018-9-2 00:00:00');
+        expect(dateToString(callback.mock.calls[1][0].startDate)).toEqual('2018-07-01');
+        expect(dateToString(callback.mock.calls[1][0].endDate)).toEqual('2018-07-02');
       });
 
       it('calls the third callback with the correct start date and resets the end date', () => {
-        expect(callback.mock.calls[2][0].startDate.toLocaleString()).toEqual('2018-9-3 00:00:00');
+        expect(dateToString(callback.mock.calls[2][0].startDate)).toEqual('2018-07-03');
         expect(callback.mock.calls[2][0].endDate).toBeNull();
       });
     });


### PR DESCRIPTION
There were some tests that were relying on the current date, now that it's October 1st, they are breaking. This PR allows you to:

- set a fixed focus date on the calendar so that deterministic tests can be written - fixes those tests that broke in a way that they won't break in 30 days time