### PR TITLE
Checks for window before runnig svg-polyfill to prevent SSR blowing up

### DIFF
--- a/packages/components/src/Popover/lib/svg-classlist-polyfill.js
+++ b/packages/components/src/Popover/lib/svg-classlist-polyfill.js
@@ -1,13 +1,15 @@
 // react-onclickoutside requires classList
 // This adds classList to SVG's to avoid errors in in IE11
-if (!('classList' in SVGElement.prototype)) {
-  Object.defineProperty(SVGElement.prototype, 'classList', {
-    get() {
-      return {
-        contains: className => (
-          this.className.baseVal.split(' ').indexOf(className) !== -1
-        ),
-      };
-    },
-  });
+if (window) {
+  if (!('classList' in SVGElement.prototype)) {
+    Object.defineProperty(SVGElement.prototype, 'classList', {
+      get() {
+        return {
+          contains: className => (
+            this.className.baseVal.split(' ').indexOf(className) !== -1
+          ),
+        };
+      },
+    });
+  }
 }


### PR DESCRIPTION
# What

When a server side rendered app tries to start and doesn't have access to window it blows up on this SVG polyfill code.

This is a quickfix to make sure it has window before it executes. The long term fix is to look at removing the PopOver component from roo-ui https://github.com/hooroo/roo-ui/issues/178