### PR TITLE
Update focus styles

### DIFF
--- a/packages/components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.js.snap
@@ -36,7 +36,7 @@ exports[`<Button /> block renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {
@@ -113,7 +113,7 @@ exports[`<Button /> primary renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {
@@ -190,7 +190,7 @@ exports[`<Button /> renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {
@@ -267,7 +267,7 @@ exports[`<Button /> rounded renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {

--- a/packages/components/src/NakedButton/NakedButton.js
+++ b/packages/components/src/NakedButton/NakedButton.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import tag from 'clean-tag';
-import { space, verticalAlign } from 'styled-system';
+import { space, verticalAlign, themeGet } from 'styled-system';
 
 const NakedButton = styled(tag.button).attrs({
   type: 'button',
@@ -16,6 +16,10 @@ const NakedButton = styled(tag.button).attrs({
   line-height: normal;
   appearance: none;
   cursor: pointer;
+
+  &:focus {
+    outline: ${themeGet('borders.2')} ${themeGet('colors.brand.secondary')};
+  }
 
   ${space} ${verticalAlign};
 `;

--- a/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
+++ b/packages/components/src/NakedButton/__snapshots__/NakedButton.test.js.snap
@@ -17,6 +17,10 @@ exports[`<NakedButton /> renders correctly 1`] = `
   cursor: pointer;
 }
 
+.c0:focus {
+  outline: 2px solid #8DE2E0;
+}
+
 <Clean.button
   blacklist={
     Array [

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -39,7 +39,7 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {
@@ -130,7 +130,7 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {
@@ -221,7 +221,7 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 2px #8DE2E0;
+  box-shadow: 0 0 2px 2px #999999;
 }
 
 .c0:disabled {

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -185,7 +185,7 @@ const shadows = {
   none: 0,
   default: '0 1px 1px 0 rgba(0, 0, 0, 0.1)',
   heavy: '0 2px 2px 0 rgba(0, 0, 0, 0.1)',
-  focus: `0 0 0 2px ${colors.brand.secondary};`,
+  focus: `0 0 2px 2px ${colors.greys.dusty};`,
 };
 
 const transitions = {


### PR DESCRIPTION
### Summary

- Update `<NakedButton />` focus style to match Link
- Set a stronger focus shadow For `<Button />`

`NakedButton`
![screen shot 2018-10-15 at 4 58 34 pm](https://user-images.githubusercontent.com/3416695/46932463-a44fc680-d09b-11e8-801c-c64c3a53b201.png)

`NakedButton:focus`
![screen shot 2018-10-15 at 4 58 43 pm](https://user-images.githubusercontent.com/3416695/46932462-a44fc680-d09b-11e8-99e0-3603f2dee96d.png)

`Button`
![screen shot 2018-10-15 at 4 58 16 pm](https://user-images.githubusercontent.com/3416695/46932466-a4e85d00-d09b-11e8-85d7-f5876654991f.png)

`Button:focus`
![screen shot 2018-10-15 at 4 58 27 pm](https://user-images.githubusercontent.com/3416695/46932465-a4e85d00-d09b-11e8-816a-a1e4ecf69412.png)
