### PR TITLE
fix: rename link inline prop

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-!/.storybook
-node_modules
 dist/
+node_modules
+!/.storybook

--- a/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
+++ b/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
@@ -44,11 +44,13 @@ exports[`<BlockLink /> renders correctly 1`] = `
       "py",
       "hidden",
       "inline",
+      "underline",
     ]
   }
   className="c0"
   hidden={false}
   inline={false}
+  underline={false}
 >
   Hello world
 </Clean.a>

--- a/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
+++ b/packages/components/src/BlockLink/__snapshots__/BlockLink.test.js.snap
@@ -43,13 +43,11 @@ exports[`<BlockLink /> renders correctly 1`] = `
       "px",
       "py",
       "hidden",
-      "inline",
       "underline",
     ]
   }
   className="c0"
   hidden={false}
-  inline={false}
   underline={false}
 >
   Hello world

--- a/packages/components/src/ExternalLink/__snapshots__/ExternalLink.test.js.snap
+++ b/packages/components/src/ExternalLink/__snapshots__/ExternalLink.test.js.snap
@@ -40,13 +40,11 @@ exports[`<ExternalLink /> renders correctly 1`] = `
       "px",
       "py",
       "hidden",
-      "inline",
       "underline",
     ]
   }
   className="c0"
   hidden={false}
-  inline={false}
   rel="noopener noreferrer"
   target="_blank"
   title="Link opens in new window"

--- a/packages/components/src/ExternalLink/__snapshots__/ExternalLink.test.js.snap
+++ b/packages/components/src/ExternalLink/__snapshots__/ExternalLink.test.js.snap
@@ -41,6 +41,7 @@ exports[`<ExternalLink /> renders correctly 1`] = `
       "py",
       "hidden",
       "inline",
+      "underline",
     ]
   }
   className="c0"
@@ -49,6 +50,7 @@ exports[`<ExternalLink /> renders correctly 1`] = `
   rel="noopener noreferrer"
   target="_blank"
   title="Link opens in new window"
+  underline={false}
 >
   Hello world
 </Clean.a>

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -30,10 +30,19 @@ const Link = styled(tag.a)`
     }
   `}
 
+  ${props => props.underline && css`
+    &, &:hover {
+      text-decoration: underline;
+      color: inherit;
+    }
+  `}
+
   ${props => props.hidden && css`
     ${hideVisually()}
   `}
 `;
+
+console.warn('[Roo-ui deprecration warning] <Link />\'s inline prop has been renamed to underline. Please update where relevant. The inline prop will be removed in the future')
 
 Link.propTypes = {
   ...color.propTypes,
@@ -42,11 +51,13 @@ Link.propTypes = {
   ...space.propTypes,
   hidden: PropTypes.bool,
   inline: PropTypes.bool,
+  underline: PropTypes.bool,
 };
 
 Link.defaultProps = {
   blacklist: Object.keys(Link.propTypes),
   inline: false,
+  underline: false,
   hidden: false,
 };
 

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -23,13 +23,6 @@ const Link = styled(tag.a)`
   ${fontWeight}
   ${space}
 
-  ${props => props.inline && css`
-    &, &:hover {
-      text-decoration: underline;
-      color: inherit;
-    }
-  `}
-
   ${props => props.underline && css`
     &, &:hover {
       text-decoration: underline;
@@ -42,21 +35,17 @@ const Link = styled(tag.a)`
   `}
 `;
 
-console.warn('[Roo-ui deprecration warning] <Link />\'s inline prop has been renamed to underline. Please update where relevant. The inline prop will be removed in the future'); // eslint-disable-line no-console
-
 Link.propTypes = {
   ...color.propTypes,
   ...hover.propTypes,
   ...fontWeight.propTypes,
   ...space.propTypes,
   hidden: PropTypes.bool,
-  inline: PropTypes.bool,
   underline: PropTypes.bool,
 };
 
 Link.defaultProps = {
   blacklist: Object.keys(Link.propTypes),
-  inline: false,
   underline: false,
   hidden: false,
 };

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -42,7 +42,7 @@ const Link = styled(tag.a)`
   `}
 `;
 
-console.warn('[Roo-ui deprecration warning] <Link />\'s inline prop has been renamed to underline. Please update where relevant. The inline prop will be removed in the future')
+console.warn('[Roo-ui deprecration warning] <Link />\'s inline prop has been renamed to underline. Please update where relevant. The inline prop will be removed in the future'); // eslint-disable-line no-console
 
 Link.propTypes = {
   ...color.propTypes,

--- a/packages/components/src/Link/Link.story.js
+++ b/packages/components/src/Link/Link.story.js
@@ -13,7 +13,7 @@ storiesOf('Components|Link', module)
       href="https://www.qantas.com"
       target="_blank"
       hidden={boolean('Hidden', false)}
-      inline={boolean('Inline', false)}
+      underline={boolean('Underline', false)}
     >
       Hello world
     </Link>

--- a/packages/components/src/Link/__snapshots__/Link.test.js.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.js.snap
@@ -39,14 +39,12 @@ exports[`<Link /> renders correctly 1`] = `
       "px",
       "py",
       "hidden",
-      "inline",
       "underline",
     ]
   }
   className="c0"
   hidden={false}
   href="/"
-  inline={false}
   underline={false}
 >
   Hello world

--- a/packages/components/src/Link/__snapshots__/Link.test.js.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.js.snap
@@ -40,12 +40,14 @@ exports[`<Link /> renders correctly 1`] = `
       "py",
       "hidden",
       "inline",
+      "underline",
     ]
   }
   className="c0"
   hidden={false}
   href="/"
   inline={false}
+  underline={false}
 >
   Hello world
 </Clean.a>


### PR DESCRIPTION
### What
**Breaking change**: Renames Link `inline` prop to `underline`

Closes https://github.com/hooroo/roo-ui/issues/193