### PR TITLE
refactor: Add new disabled style for Button and OutlineButton

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 dist/
-node_modules
+node_modules/
 !/.storybook

--- a/packages/components/src/Button/Button.js
+++ b/packages/components/src/Button/Button.js
@@ -39,11 +39,6 @@ const Button = styled(tag.button)`
     box-shadow: ${themeGet('shadows.focus')};
   }
 
-  &:disabled {
-    opacity: ${themeGet('opacity.disabled')};
-    cursor: not-allowed;
-  }
-
   ${props => props.rounded && css`
     border-radius: ${themeGet('radii.rounded')};
   `}

--- a/packages/components/src/Button/Button.js
+++ b/packages/components/src/Button/Button.js
@@ -39,6 +39,12 @@ const Button = styled(tag.button)`
     box-shadow: ${themeGet('shadows.focus')};
   }
 
+  &:disabled {
+    background-color: ${themeGet('colors.greys.steel')};
+    color: white;
+    cursor: not-allowed;
+  }
+
   ${props => props.rounded && css`
     border-radius: ${themeGet('radii.rounded')};
   `}

--- a/packages/components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.js.snap
@@ -39,6 +39,12 @@ exports[`<Button /> block renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
+}
+
 <Clean.button
   blacklist={
     Array [
@@ -109,6 +115,12 @@ exports[`<Button /> primary renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
+}
+
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
 }
 
 <Clean.button
@@ -183,6 +195,12 @@ exports[`<Button /> renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
+}
+
 <Clean.button
   blacklist={
     Array [
@@ -253,6 +271,12 @@ exports[`<Button /> rounded renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
+}
+
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
 }
 
 <Clean.button

--- a/packages/components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.js.snap
@@ -39,11 +39,6 @@ exports[`<Button /> block renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
 <Clean.button
   blacklist={
     Array [
@@ -114,11 +109,6 @@ exports[`<Button /> primary renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
-}
-
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
 }
 
 <Clean.button
@@ -193,11 +183,6 @@ exports[`<Button /> renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
 <Clean.button
   blacklist={
     Array [
@@ -268,11 +253,6 @@ exports[`<Button /> rounded renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
-}
-
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
 }
 
 <Clean.button

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -42,6 +42,12 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
+}
+
 .c0:not(:hover),
 .c0:disabled {
   color: #E40000;
@@ -128,6 +134,12 @@ exports[`<OutlineButton /> renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
+}
+
 .c0:not(:hover),
 .c0:disabled {
   color: #323232;
@@ -212,6 +224,12 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
+}
+
+.c0:disabled {
+  background-color: #666666;
+  color: white;
+  cursor: not-allowed;
 }
 
 .c0:not(:hover),

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -42,11 +42,6 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
 .c0:not(:hover),
 .c0:disabled {
   color: #E40000;
@@ -133,11 +128,6 @@ exports[`<OutlineButton /> renders correctly 1`] = `
   box-shadow: 0 0 2px 2px #999999;
 }
 
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
 .c0:not(:hover),
 .c0:disabled {
   color: #323232;
@@ -222,11 +212,6 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 
 .c0:focus {
   box-shadow: 0 0 2px 2px #999999;
-}
-
-.c0:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
 }
 
 .c0:not(:hover),

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -203,8 +203,8 @@ const buttons = {
   },
   disabled: {
     cursor: 'not-allowed',
-    color: greys.dusty,
-    backgroundColor: greys.alto,
+    color: 'white',
+    backgroundColor: greys.steel,
   },
 };
 

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -201,6 +201,11 @@ const buttons = {
     color: 'white',
     backgroundColor: colors.brand.primary,
   },
+  disabled: {
+    cursor: 'not-allowed',
+    color: greys.dusty,
+    backgroundColor: greys.alto,
+  },
 };
 
 const alertStyles = {

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -201,11 +201,6 @@ const buttons = {
     color: 'white',
     backgroundColor: colors.brand.primary,
   },
-  disabled: {
-    cursor: 'not-allowed',
-    color: 'white',
-    backgroundColor: greys.steel,
-  },
 };
 
 const alertStyles = {


### PR DESCRIPTION
Our buttons (Button and NakedButton) in a disabled state should be inline with other Qantas apps (we've used book.qantas.com and qantas assure as our example).

Should look like this:
![screen shot 2018-11-16 at 2 08 24 pm](https://user-images.githubusercontent.com/7961537/48595899-b9758900-e9aa-11e8-9d8c-ba0b22b2c3c8.png)


**Before**:
![screen shot 2018-11-16 at 2 19 34 pm](https://user-images.githubusercontent.com/7961537/48595927-d0b47680-e9aa-11e8-8ceb-cf177daa4faf.png)
![screen shot 2018-11-16 at 2 19 40 pm](https://user-images.githubusercontent.com/7961537/48595929-d0b47680-e9aa-11e8-8f1e-a1756b1456aa.png)



**After**:
![screen shot 2018-11-16 at 2 21 14 pm](https://user-images.githubusercontent.com/7961537/48595951-eaee5480-e9aa-11e8-9cfa-b76837251e28.png)
