### PR TITLE
Allow Input to accept readonly variations

### DIFF
--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -61,7 +61,6 @@ Input.propTypes = {
   ...borderColor.propTypes,
   error: PropTypes.bool,
   underline: PropTypes.bool,
-  readonlyVariant: PropTypes.string,
 };
 
 Input.defaultProps = {

--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -1,20 +1,31 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { space, themeGet } from 'styled-system';
+import {
+  space,
+  color,
+  fontSize,
+  lineHeight,
+  border,
+  borderColor,
+  themeGet,
+  variant,
+} from 'styled-system';
 import tag from 'clean-tag';
 
+const readonlyVariant = variant({
+  prop: 'readonlyVariant',
+  key: 'readonlyStyles',
+});
+
 const Input = styled(tag)`
+  ${space}
+  ${color}
+  ${fontSize}
+  ${lineHeight}
+  ${border}
+  ${borderColor}
   display: block;
   width: 100%;
-  margin: 0;
-  margin-bottom: ${themeGet('space.3')};
-  padding: ${themeGet('space.3')} ${themeGet('space.4')};
-  font-size: ${themeGet('fontSizes.base')};
-  line-height: ${themeGet('lineHeights.normal')};
-  color: ${themeGet('colors.greys.charcoal')};
-  background-color: ${themeGet('colors.white')};
-  border: ${themeGet('borders.2')};
-  border-color: ${themeGet('colors.greys.alto')};
   outline: 0;
   transition: border-color ${themeGet('transitions.default')};
   appearance: none;
@@ -29,9 +40,7 @@ const Input = styled(tag)`
   }
 
   &[readonly] {
-    border-color: transparent;
-    background: transparent;
-    padding-left: 0;
+    ${readonlyVariant}
   }
 
   ::placeholder {
@@ -51,18 +60,32 @@ const Input = styled(tag)`
   ${props => props.error && css`
     border-color: ${themeGet('colors.ui.error')};
   `}
-
-  ${space};
 `;
 
 Input.propTypes = {
   ...space.propTypes,
+  ...color.propTypes,
+  ...fontSize.propTypes,
+  ...lineHeight.propTypes,
+  ...border.propTypes,
+  ...borderColor.propTypes,
   error: PropTypes.bool,
   underline: PropTypes.bool,
+  readonlyVariant: PropTypes.string,
 };
 
 Input.defaultProps = {
   is: 'input',
+  mb: 3,
+  py: 3,
+  px: 4,
+  bg: 'white',
+  color: 'greys.charcoal',
+  fontSize: 'base',
+  lineHeight: 'normal',
+  border: 2,
+  borderColor: 'greys.alto',
+  readonlyVariant: 'naked',
   blacklist: Object.keys(Input.propTypes),
 };
 

--- a/packages/components/src/Input/Input.js
+++ b/packages/components/src/Input/Input.js
@@ -8,14 +8,8 @@ import {
   border,
   borderColor,
   themeGet,
-  variant,
 } from 'styled-system';
 import tag from 'clean-tag';
-
-const readonlyVariant = variant({
-  prop: 'readonlyVariant',
-  key: 'readonlyStyles',
-});
 
 const Input = styled(tag)`
   ${space}
@@ -37,10 +31,6 @@ const Input = styled(tag)`
   &:disabled {
     opacity: ${themeGet('opacity.disabled')};
     cursor: not-allowed;
-  }
-
-  &[readonly] {
-    ${readonlyVariant}
   }
 
   ::placeholder {
@@ -85,7 +75,6 @@ Input.defaultProps = {
   lineHeight: 'normal',
   border: 2,
   borderColor: 'greys.alto',
-  readonlyVariant: 'naked',
   blacklist: Object.keys(Input.propTypes),
 };
 

--- a/packages/components/src/Input/__snapshots__/Input.test.js.snap
+++ b/packages/components/src/Input/__snapshots__/Input.test.js.snap
@@ -2,15 +2,35 @@
 
 exports[`<Input /> renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is="input"
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
 />
 `;
 
 exports[`<Input /> underline renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is="input"
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
   underline={true}
 />
 `;

--- a/packages/components/src/Input/__snapshots__/Input.test.js.snap
+++ b/packages/components/src/Input/__snapshots__/Input.test.js.snap
@@ -13,7 +13,6 @@ exports[`<Input /> renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
 />
 `;
 
@@ -30,7 +29,6 @@ exports[`<Input /> underline renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
   underline={true}
 />
 `;

--- a/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
+++ b/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
@@ -2,9 +2,15 @@
 
 exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is="input"
   keepCharPositions={true}
+  lineHeight="normal"
   mask={
     Array [
       /\\[0-2\\]/,
@@ -15,17 +21,27 @@ exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
       " AEST",
     ]
   }
+  mb={3}
   placeholder="00:00 AEST"
   placeholderChar=" "
+  px={4}
+  py={3}
+  readonlyVariant="naked"
   render={[Function]}
 />
 `;
 
 exports[`<MaskedInput /> renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   id="postcode"
   is="input"
+  lineHeight="normal"
   mask={
     Array [
       /\\\\d/,
@@ -34,7 +50,11 @@ exports[`<MaskedInput /> renders correctly 1`] = `
       /\\\\d/,
     ]
   }
+  mb={3}
   placeholder="Enter postcode"
+  px={4}
+  py={3}
+  readonlyVariant="naked"
   render={[Function]}
 />
 `;

--- a/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
+++ b/packages/components/src/MaskedInput/__snapshots__/MaskedInput.test.js.snap
@@ -26,7 +26,6 @@ exports[`<MaskedInput /> <MaskedInput.time /> renders correctly 1`] = `
   placeholderChar=" "
   px={4}
   py={3}
-  readonlyVariant="naked"
   render={[Function]}
 />
 `;
@@ -54,7 +53,6 @@ exports[`<MaskedInput /> renders correctly 1`] = `
   placeholder="Enter postcode"
   px={4}
   py={3}
-  readonlyVariant="naked"
   render={[Function]}
 />
 `;

--- a/packages/components/src/PasswordInput/PasswordInput.js
+++ b/packages/components/src/PasswordInput/PasswordInput.js
@@ -6,7 +6,7 @@ import cleanElement from 'clean-element';
 
 import { Input, Icon, NakedButton } from '..';
 
-const CleanInput = cleanElement('input');
+const CleanInput = cleanElement(Input);
 CleanInput.propTypes = Input.propTypes;
 CleanInput.displayName = 'PasswordInput__Input';
 

--- a/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -40,12 +40,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   cursor: not-allowed;
 }
 
-.c2[readonly] {
-  border-color: transparent;
-  background: transparent;
-  padding-left: 0;
-}
-
 .c2::-webkit-input-placeholder {
   color: #666666;
 }
@@ -172,7 +166,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                 mb={3}
                 px={4}
                 py={3}
-                readonlyVariant="naked"
                 type="password"
               >
                 <StyledComponent
@@ -188,7 +181,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                   mb={3}
                   px={4}
                   py={3}
-                  readonlyVariant="naked"
                   type="password"
                 >
                   <Clean.div
@@ -203,7 +195,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                     mb={3}
                     px={4}
                     py={3}
-                    readonlyVariant="naked"
                     type="password"
                   >
                     <input
@@ -329,12 +320,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
 .c2:disabled {
   opacity: 0.7;
   cursor: not-allowed;
-}
-
-.c2[readonly] {
-  border-color: transparent;
-  background: transparent;
-  padding-left: 0;
 }
 
 .c2::-webkit-input-placeholder {
@@ -463,7 +448,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                 mb={3}
                 px={4}
                 py={3}
-                readonlyVariant="naked"
                 type="text"
               >
                 <StyledComponent
@@ -479,7 +463,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                   mb={3}
                   px={4}
                   py={3}
-                  readonlyVariant="naked"
                   type="text"
                 >
                   <Clean.div
@@ -494,7 +477,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                     mb={3}
                     px={4}
                     py={3}
-                    readonlyVariant="naked"
                     type="text"
                   >
                     <input

--- a/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] = `
-.c3 {
+.c4 {
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -9,11 +9,68 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   margin-right: 8px;
 }
 
+.c2 {
+  margin-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #323232;
+  background-color: #FFFFFF;
+  font-size: 1rem;
+  line-height: 1.35;
+  border: 2px solid;
+  border-color: #DADADA;
+  display: block;
+  width: 100%;
+  outline: 0;
+  -webkit-transition: border-color 200ms ease-in;
+  transition: border-color 200ms ease-in;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c2:focus {
+  border-color: #8DE2E0;
+}
+
+.c2:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.c2[readonly] {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #666666;
+}
+
+.c2::-moz-placeholder {
+  color: #666666;
+}
+
+.c2:-ms-input-placeholder {
+  color: #666666;
+}
+
+.c2::placeholder {
+  color: #666666;
+}
+
+.c2::-ms-clear {
+  display: none;
+}
+
 .c1 {
   position: relative;
 }
 
-.c2 {
+.c3 {
   border: none;
   margin: 0;
   padding: 0;
@@ -35,29 +92,20 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   text-decoration: underline;
 }
 
-.c2:focus {
+.c3:focus {
   outline: none;
 }
 
 .c0 {
+  padding-right: 5.625rem;
   display: block;
   width: 100%;
-  margin: 0;
-  margin-bottom: 0.75rem;
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-  line-height: 1.35;
-  color: #323232;
-  background-color: #FFFFFF;
-  border: 2px solid;
-  border-color: #DADADA;
   outline: 0;
   -webkit-transition: border-color 200ms ease-in;
   transition: border-color 200ms ease-in;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding-right: 5.625rem;
 }
 
 .c0:focus {
@@ -67,12 +115,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
 .c0:disabled {
   opacity: 0.7;
   cursor: not-allowed;
-}
-
-.c0[readonly] {
-  border-color: transparent;
-  background: transparent;
-  padding-left: 0;
 }
 
 .c0::-webkit-input-placeholder {
@@ -118,10 +160,59 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
               pr="5.625rem"
               type="password"
             >
-              <input
+              <Input
+                bg="white"
+                border={2}
+                borderColor="greys.alto"
                 className="-Base c0"
+                color="greys.charcoal"
+                fontSize="base"
+                is="input"
+                lineHeight="normal"
+                mb={3}
+                px={4}
+                py={3}
+                readonlyVariant="naked"
                 type="password"
-              />
+              >
+                <StyledComponent
+                  bg="white"
+                  border={2}
+                  borderColor="greys.alto"
+                  className="-Base c0"
+                  color="greys.charcoal"
+                  fontSize="base"
+                  forwardedRef={null}
+                  is="input"
+                  lineHeight="normal"
+                  mb={3}
+                  px={4}
+                  py={3}
+                  readonlyVariant="naked"
+                  type="password"
+                >
+                  <Clean.div
+                    bg="white"
+                    border={2}
+                    borderColor="greys.alto"
+                    className="-Base c0 Input-sc-8xufa8-0 c2"
+                    color="greys.charcoal"
+                    fontSize="base"
+                    is="input"
+                    lineHeight="normal"
+                    mb={3}
+                    px={4}
+                    py={3}
+                    readonlyVariant="naked"
+                    type="password"
+                  >
+                    <input
+                      className="-Base c0 Input-sc-8xufa8-0 c2"
+                      type="password"
+                    />
+                  </Clean.div>
+                </StyledComponent>
+              </Input>
             </PasswordInput__Input>
             <PasswordInput__Toggle
               is="button"
@@ -133,13 +224,13 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                 onClick={[Function]}
               >
                 <Clean.div
-                  className="c2"
+                  className="c3"
                   is="button"
                   onClick={[Function]}
                   type="button"
                 >
                   <button
-                    className="c2"
+                    className="c3"
                     onClick={[Function]}
                     type="button"
                   >
@@ -155,14 +246,14 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                         size={22}
                       >
                         <Base
-                          className="c3"
+                          className="c4"
                           mr={2}
                           name="visibility"
                           size={22}
                           title={null}
                         >
                           <Cleaned
-                            className="c3"
+                            className="c4"
                             fill="currentcolor"
                             height={22}
                             mr={2}
@@ -171,7 +262,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                             width={22}
                           >
                             <svg
-                              className="c3"
+                              className="c4"
                               fill="currentcolor"
                               height={22}
                               mr={2}
@@ -201,7 +292,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
 `;
 
 exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
-.c3 {
+.c4 {
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -209,11 +300,68 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   margin-right: 8px;
 }
 
+.c2 {
+  margin-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #323232;
+  background-color: #FFFFFF;
+  font-size: 1rem;
+  line-height: 1.35;
+  border: 2px solid;
+  border-color: #DADADA;
+  display: block;
+  width: 100%;
+  outline: 0;
+  -webkit-transition: border-color 200ms ease-in;
+  transition: border-color 200ms ease-in;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c2:focus {
+  border-color: #8DE2E0;
+}
+
+.c2:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.c2[readonly] {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #666666;
+}
+
+.c2::-moz-placeholder {
+  color: #666666;
+}
+
+.c2:-ms-input-placeholder {
+  color: #666666;
+}
+
+.c2::placeholder {
+  color: #666666;
+}
+
+.c2::-ms-clear {
+  display: none;
+}
+
 .c1 {
   position: relative;
 }
 
-.c2 {
+.c3 {
   border: none;
   margin: 0;
   padding: 0;
@@ -235,29 +383,20 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   text-decoration: underline;
 }
 
-.c2:focus {
+.c3:focus {
   outline: none;
 }
 
 .c0 {
+  padding-right: 5.625rem;
   display: block;
   width: 100%;
-  margin: 0;
-  margin-bottom: 0.75rem;
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-  line-height: 1.35;
-  color: #323232;
-  background-color: #FFFFFF;
-  border: 2px solid;
-  border-color: #DADADA;
   outline: 0;
   -webkit-transition: border-color 200ms ease-in;
   transition: border-color 200ms ease-in;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding-right: 5.625rem;
 }
 
 .c0:focus {
@@ -267,12 +406,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
 .c0:disabled {
   opacity: 0.7;
   cursor: not-allowed;
-}
-
-.c0[readonly] {
-  border-color: transparent;
-  background: transparent;
-  padding-left: 0;
 }
 
 .c0::-webkit-input-placeholder {
@@ -318,10 +451,59 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
               pr="5.625rem"
               type="text"
             >
-              <input
+              <Input
+                bg="white"
+                border={2}
+                borderColor="greys.alto"
                 className="-Base c0"
+                color="greys.charcoal"
+                fontSize="base"
+                is="input"
+                lineHeight="normal"
+                mb={3}
+                px={4}
+                py={3}
+                readonlyVariant="naked"
                 type="text"
-              />
+              >
+                <StyledComponent
+                  bg="white"
+                  border={2}
+                  borderColor="greys.alto"
+                  className="-Base c0"
+                  color="greys.charcoal"
+                  fontSize="base"
+                  forwardedRef={null}
+                  is="input"
+                  lineHeight="normal"
+                  mb={3}
+                  px={4}
+                  py={3}
+                  readonlyVariant="naked"
+                  type="text"
+                >
+                  <Clean.div
+                    bg="white"
+                    border={2}
+                    borderColor="greys.alto"
+                    className="-Base c0 Input-sc-8xufa8-0 c2"
+                    color="greys.charcoal"
+                    fontSize="base"
+                    is="input"
+                    lineHeight="normal"
+                    mb={3}
+                    px={4}
+                    py={3}
+                    readonlyVariant="naked"
+                    type="text"
+                  >
+                    <input
+                      className="-Base c0 Input-sc-8xufa8-0 c2"
+                      type="text"
+                    />
+                  </Clean.div>
+                </StyledComponent>
+              </Input>
             </PasswordInput__Input>
             <PasswordInput__Toggle
               is="button"
@@ -333,13 +515,13 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                 onClick={[Function]}
               >
                 <Clean.div
-                  className="c2"
+                  className="c3"
                   is="button"
                   onClick={[Function]}
                   type="button"
                 >
                   <button
-                    className="c2"
+                    className="c3"
                     onClick={[Function]}
                     type="button"
                   >
@@ -355,14 +537,14 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                         size={22}
                       >
                         <Base
-                          className="c3"
+                          className="c4"
                           mr={2}
                           name="visibilityOff"
                           size={22}
                           title={null}
                         >
                           <Cleaned
-                            className="c3"
+                            className="c4"
                             fill="currentcolor"
                             height={22}
                             mr={2}
@@ -371,7 +553,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                             width={22}
                           >
                             <svg
-                              className="c3"
+                              className="c4"
                               fill="currentcolor"
                               height={22}
                               mr={2}

--- a/packages/components/src/Select/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.js.snap
@@ -14,7 +14,6 @@ exports[`<Select /> disabled renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -34,7 +33,6 @@ exports[`<Select /> readOnly renders correctly 1`] = `
   px={4}
   py={3}
   readOnly={true}
-  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -53,7 +51,6 @@ exports[`<Select /> renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -72,7 +69,6 @@ exports[`<Select /> underline renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
   underline={true}
 >
   Options

--- a/packages/components/src/Select/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.js.snap
@@ -2,9 +2,19 @@
 
 exports[`<Select /> disabled renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
   disabled={true}
+  fontSize="base"
   forwardedRef={null}
   is={[Function]}
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -12,9 +22,19 @@ exports[`<Select /> disabled renders correctly 1`] = `
 
 exports[`<Select /> readOnly renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is={[Function]}
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
   readOnly={true}
+  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -22,8 +42,18 @@ exports[`<Select /> readOnly renders correctly 1`] = `
 
 exports[`<Select /> renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is={[Function]}
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
 >
   Options
 </StyledComponent>
@@ -31,8 +61,18 @@ exports[`<Select /> renders correctly 1`] = `
 
 exports[`<Select /> underline renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is={[Function]}
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
   underline={true}
 >
   Options

--- a/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
@@ -13,7 +13,6 @@ exports[`<Textarea /> renders correctly 1`] = `
   mb={3}
   px={4}
   py={3}
-  readonlyVariant="naked"
   rows={6}
 >
   Hello World

--- a/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/packages/components/src/Textarea/__snapshots__/Textarea.test.js.snap
@@ -2,8 +2,18 @@
 
 exports[`<Textarea /> renders correctly 1`] = `
 <StyledComponent
+  bg="white"
+  border={2}
+  borderColor="greys.alto"
+  color="greys.charcoal"
+  fontSize="base"
   forwardedRef={null}
   is="textarea"
+  lineHeight="normal"
+  mb={3}
+  px={4}
+  py={3}
+  readonlyVariant="naked"
   rows={6}
 >
   Hello World

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -236,6 +236,18 @@ const opacity = {
   disabled: 0.7,
 };
 
+const readonlyStyles = {
+  naked: {
+    borderColor: 'transparent',
+    background: 'transparent',
+    paddingLeft: 0,
+  },
+  dimmed: {
+    background: colors.greys.porcelain,
+    color: colors.greys.steel,
+  },
+};
+
 export default {
   gutters,
   colors,
@@ -256,4 +268,5 @@ export default {
   buttons,
   alertStyles,
   opacity,
+  readonlyStyles,
 };

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -236,18 +236,6 @@ const opacity = {
   disabled: 0.7,
 };
 
-const readonlyStyles = {
-  naked: {
-    borderColor: 'transparent',
-    background: 'transparent',
-    paddingLeft: 0,
-  },
-  dimmed: {
-    background: colors.greys.porcelain,
-    color: colors.greys.steel,
-  },
-};
-
 export default {
   gutters,
   colors,
@@ -268,5 +256,4 @@ export default {
   buttons,
   alertStyles,
   opacity,
-  readonlyStyles,
 };


### PR DESCRIPTION
We have a few designs in our app where we need to set an input to readonly, but we still want it to look like an input (just greyed out). The only way to do this right now is to extend the component and then overwrite the css (which bloats the css that styled components outputs).

The last version of `styled-system` has consolidated many utilities into the `variant` function which is used here to make the readonly styled extensible.