### PR TITLE
Allow label margins to be changed without extending

### DIFF
--- a/packages/components/src/Label/Label.js
+++ b/packages/components/src/Label/Label.js
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { hideVisually } from 'polished';
-import { themeGet, textStyle, space } from 'styled-system';
+import { textStyle, space } from 'styled-system';
 import tag from 'clean-tag';
 
 const Label = styled(tag.label)`
   display: block;
   width: 100%;
-  margin: 0;
-  margin-bottom: ${themeGet('space.3')};
 
   ${props => props.hidden && hideVisually()}
 
@@ -24,6 +22,8 @@ Label.propTypes = {
 
 Label.defaultProps = {
   textStyle: 'label',
+  m: 0,
+  mb: 3,
   hidden: false,
 };
 

--- a/packages/components/src/Label/__snapshots__/Label.test.js.snap
+++ b/packages/components/src/Label/__snapshots__/Label.test.js.snap
@@ -4,6 +4,8 @@ exports[`<Label /> hidden renders correctly 1`] = `
 <StyledComponent
   forwardedRef={null}
   hidden={true}
+  m={0}
+  mb={3}
   textStyle="label"
 >
   Hello world
@@ -14,6 +16,8 @@ exports[`<Label /> renders correctly 1`] = `
 <StyledComponent
   forwardedRef={null}
   hidden={false}
+  m={0}
+  mb={3}
   textStyle="label"
 >
   Hello world


### PR DESCRIPTION
By switching from fixed styles using `themeGet` to default props, we allow apps to change the margins without extending the components.