### PR TITLE
update Button to be more resilliant to extension

### DIFF
--- a/packages/components/src/Button/Button.js
+++ b/packages/components/src/Button/Button.js
@@ -5,10 +5,12 @@ import tag from 'clean-tag';
 import { themeGet, space, color, bgColor, boxShadow, variant } from 'styled-system';
 import get from 'lodash/get';
 
+const FALLBACK_BG_COLOR = '#000';
+
 const buttonStyle = variant({ key: 'buttons' });
 
 const getBackground = props =>
-  get(bgColor(props), 'backgroundColor') || get(buttonStyle(props), 'backgroundColor');
+  get(bgColor(props), 'backgroundColor') || get(buttonStyle(props), 'backgroundColor') || FALLBACK_BG_COLOR;
 
 const Button = styled(tag.button)`
   display: inline-block;
@@ -34,8 +36,12 @@ const Button = styled(tag.button)`
   ${color}
   ${boxShadow}
 
-  &:hover:not(:disabled) {
+  &:hover {
     background-color: ${props => darken(0.1, getBackground(props))};
+  }
+
+  &:hover:disabled {
+    background-color: ${props => getBackground(props)};
   }
 
   &:focus {

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -36,8 +36,12 @@ exports[`<OutlineButton /> renders correctly 1`] = `
   transition: none;
 }
 
-.c0:hover:not(:disabled) {
+.c0:hover {
   background-color: #181818;
+}
+
+.c0:hover:disabled {
+  background-color: #323232;
 }
 
 .c0:focus {


### PR DESCRIPTION
This PR makes the Button more resilient to extension. Previously we had seen to issues:

1. The only way to create a variant that with different hover styles was to add specificity in a non-standard way `'&&:hover:not(:disabled)'`
2. If a background color was non explicitly set, the darken function from polished would receive null and throw a cryptic error that was hard to debug.