### PR TITLE
feat: Use styledOmitProps for Box, Label, Link & Text

### DIFF
--- a/packages/components/src/Box/Box.js
+++ b/packages/components/src/Box/Box.js
@@ -1,4 +1,3 @@
-import styled from 'styled-components';
 import {
   display,
   space,
@@ -19,8 +18,9 @@ import {
   position,
   zIndex,
 } from 'styled-system';
+import styled from '../styledOmitProps';
 
-const Box = styled.div`
+const Box = styled('div')`
   ${display}
   ${space}
   ${width}

--- a/packages/components/src/Label/Label.js
+++ b/packages/components/src/Label/Label.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { hideVisually } from 'polished';
 import { textStyle, space } from 'styled-system';
+import styled, { VALID_STYLED_SYSTEM_PROPS } from '../styledOmitProps';
 
-const Label = styled.label`
+const Label = styled('label', { omit: [...VALID_STYLED_SYSTEM_PROPS, 'hidden'] })`
   display: block;
   width: 100%;
 

--- a/packages/components/src/Label/Label.js
+++ b/packages/components/src/Label/Label.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import { hideVisually } from 'polished';
 import { textStyle, space } from 'styled-system';
-import styled, { VALID_STYLED_SYSTEM_PROPS } from '../styledOmitProps';
+import styled from '../styledOmitProps';
 
-const Label = styled('label', { omit: [...VALID_STYLED_SYSTEM_PROPS, 'hidden'] })`
+const Label = styled('label', { omit: ['hidden'] })`
   display: block;
   width: 100%;
 

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import { hideVisually } from 'polished';
 import { color, fontWeight, themeGet, space } from 'styled-system';
-import styledOmitProps, { VALID_STYLED_SYSTEM_PROPS } from '../styledOmitProps';
+import styledOmitProps from '../styledOmitProps';
 
-const Link = styledOmitProps('a', { omit: [...VALID_STYLED_SYSTEM_PROPS, 'hidden'] })`
+const Link = styledOmitProps('a', { omit: ['hidden'] })`
   cursor: pointer;
   text-decoration: none;
   display: inline-block;

--- a/packages/components/src/Link/Link.js
+++ b/packages/components/src/Link/Link.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import { hideVisually } from 'polished';
 import { color, fontWeight, themeGet, space } from 'styled-system';
-import styledOmitProps from '../styledOmitProps';
+import styledOmitProps, { VALID_STYLED_SYSTEM_PROPS } from '../styledOmitProps';
 
-const Link = styledOmitProps('a', { omit: ['hidden'] })`
+const Link = styledOmitProps('a', { omit: [...VALID_STYLED_SYSTEM_PROPS, 'hidden'] })`
   cursor: pointer;
   text-decoration: none;
   display: inline-block;

--- a/packages/components/src/Text/Text.js
+++ b/packages/components/src/Text/Text.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import { css } from 'styled-components';
 import { hideVisually } from 'polished';
 import {
   textStyle,
@@ -13,13 +13,14 @@ import {
   style,
   display,
 } from 'styled-system';
+import styled from '../styledOmitProps';
 
 const textDecoration = style({
   prop: 'textDecoration',
   cssProperty: 'textDecoration',
 });
 
-const Text = styled.span`
+const Text = styled('span')`
   ${textStyle}
   ${color}
   ${fontSize}

--- a/packages/components/src/styledOmitProps/styledOmitProps.js
+++ b/packages/components/src/styledOmitProps/styledOmitProps.js
@@ -4,14 +4,21 @@ import { pickBy, omit } from 'lodash';
 import styled from 'styled-components';
 import { VALID_STYLED_SYSTEM_PROPS } from './constants';
 
-const styledOmitProps = (component, options = { omit: VALID_STYLED_SYSTEM_PROPS }) => {
-  if (options === undefined || options.omit === undefined || options.omit.constructor !== Array) {
+const styledOmitProps = (component, {
+  omit: customPropsToOmit = [],
+  omitStyledSystemProps = true,
+} = {}) => {
+  const propsToOmit = omitStyledSystemProps
+    ? [...customPropsToOmit, ...VALID_STYLED_SYSTEM_PROPS]
+    : customPropsToOmit;
+
+  if (propsToOmit.length === 0) {
     return styled(component);
   }
 
   const omittedPropsComponent = React.forwardRef((props, ref) => {
     const validProps = pickBy(props, (_, prop) => isPropValid(prop));
-    const filteredProps = omit(validProps, options.omit);
+    const filteredProps = omit(validProps, propsToOmit);
     return React.createElement(component, { ...filteredProps, ref });
   });
 

--- a/packages/components/src/styledOmitProps/styledOmitProps.test.js
+++ b/packages/components/src/styledOmitProps/styledOmitProps.test.js
@@ -2,74 +2,60 @@ import React from 'react';
 import { mount } from 'enzyme';
 import styledOmitProps from '.';
 
-it('creates an unfiltered component if supplied a single argument', () => {
-  const Span = styledOmitProps('span')``;
-  const wrapper = mount(<Span hidden>Text</Span>);
-  const domNode = wrapper.find('span').getDOMNode();
-  expect(wrapper.find('span').prop('hidden')).toEqual(true);
-  expect(domNode.getAttribute('hidden')).toEqual('');
-});
-
-it('renders valid html attributes that are not in the filter list', () => {
-  const Span = styledOmitProps('span', { omit: ['not-color'] })``;
-  const wrapper = mount(<Span color="red">Text</Span>);
-  const domNode = wrapper.find('span').getDOMNode();
-  expect(wrapper.find('span').prop('color')).toEqual('red');
-  expect(domNode.getAttribute('color')).toEqual('red');
-  expect(wrapper.find('span').prop('not-color')).toBeUndefined();
-  expect(domNode.getAttribute('not-color')).toEqual(null);
-});
-
-it('does not render valid html attributes that are filtered', () => {
-  const Span = styledOmitProps('span', { omit: ['color'] })``;
-  const wrapper = mount(<Span color="red">Text</Span>);
-  const domNode = wrapper.find('span').getDOMNode();
-  expect(wrapper.find('span').prop('color')).toBeUndefined();
-  expect(domNode.getAttribute('color')).toEqual(null);
-});
-
-it('does not render styled-system props that are also valid html props', () => {
-  const Span = styledOmitProps('span')``;
-  const wrapper = mount(<Span fontSize="30">Text</Span>);
-  const domNode = wrapper.find('span').getDOMNode();
-  expect(wrapper.find('span').prop('fontSize')).toBeUndefined();
-  expect(domNode.getAttribute('font-size')).toEqual(null);
-});
-
-describe('invalid html props', () => {
-  describe('when no options provided', () => {
-    let wrapper;
-    let domNode;
-
-    beforeEach(() => {
-      const Span = styledOmitProps('span')``;
-      wrapper = mount(<Span mb={12} p={4}>Text</Span>);
-      domNode = wrapper.find('span').getDOMNode();
-    });
-
-    it('does not render invalid html props', () => {
-      expect(wrapper.find('span').prop('mb')).toBeUndefined();
-      expect(wrapper.find('span').prop('p')).toBeUndefined();
-      expect(domNode.getAttribute('mb')).toEqual(null);
-      expect(domNode.getAttribute('p')).toEqual(null);
-    });
+const itRendersValidHtmlAttrubutes = (TestComponent) => {
+  it('renders valid html attrubutes', () => {
+    expect(mount(<TestComponent id="test-component" />).find('span').prop('id')).toBe('test-component');
   });
+};
 
-  describe('when options provided', () => {
-    let wrapper;
-    let domNode;
+const itFiltersOutInvalidHtmlAttributes = (TestComponent) => {
+  it('filters out invalid html attributes', () => {
+    expect(mount(<TestComponent beastMode />).find('span').prop('beastMode')).toBe(undefined);
+  });
+};
 
-    beforeEach(() => {
-      const Span = styledOmitProps('span', { omit: ['color'] })``;
-      wrapper = mount(<Span color="red" mb={12} p={4}>Text</Span>);
-      domNode = wrapper.find('span').getDOMNode();
-    });
+const itFiltersOutValidHtmlAttributesThatAreAlsoStyledSystemProps = (TestComponent) => {
+  it('filters out valid html attributes that are also styled system props', () => {
+    expect(mount(<TestComponent fontSize={5} />).find('span').prop('fontSize')).toBe(undefined);
+  });
+};
 
-    it('does not render omitted props in addition to invalid html props', () => {
-      expect(wrapper.find('span').prop('mb')).toBeUndefined();
-      expect(wrapper.find('span').prop('p')).toBeUndefined();
-      expect(domNode.getAttribute('mb')).toEqual(null);
-      expect(domNode.getAttribute('p')).toEqual(null);
-    });
+const itRendersValidHtmlAttributesThatAreAlsoStyledSystemProps = (TestComponent) => {
+  it('renders valid html attributes that are also styled system props', () => {
+    expect(mount(<TestComponent fontSize={5} />).find('span').prop('fontSize')).toBe(5);
+  });
+};
+
+describe('without options', () => {
+  const Component = styledOmitProps('span')``;
+
+  itRendersValidHtmlAttrubutes(Component);
+
+  itFiltersOutInvalidHtmlAttributes(Component);
+
+  itFiltersOutValidHtmlAttributesThatAreAlsoStyledSystemProps(Component);
+});
+
+describe('with omitStyledSystemProps = false', () => {
+  const Component = styledOmitProps('span', { omitStyledSystemProps: false })``;
+
+  itRendersValidHtmlAttrubutes(Component);
+
+  itFiltersOutInvalidHtmlAttributes(Component);
+
+  itRendersValidHtmlAttributesThatAreAlsoStyledSystemProps(Component);
+});
+
+describe('with "data-testid" in omit list', () => {
+  const Component = styledOmitProps('span', { omit: ['data-testid'] })``;
+
+  itRendersValidHtmlAttrubutes(Component);
+
+  itFiltersOutInvalidHtmlAttributes(Component);
+
+  itFiltersOutValidHtmlAttributesThatAreAlsoStyledSystemProps(Component);
+
+  it('filters out "data-testid"', () => {
+    expect(mount(<Component data-testid="test-component" />).find('span').prop('data-testid')).toBe(undefined);
   });
 });


### PR DESCRIPTION
Use `styledOmitProps` for commonly used base components: Box, Label, Link & Text.

I stop short of using it in `Heading` as I notice the omit functionality doesn't work when using styled-components `as` prop.

But adding in on the above components brought the number of DOM nodes with leaked attributes down from ~900 to ~50.

For reference, this is how I tested for leaked props
```js
document.querySelectorAll('[m]:not(svg):not(img), [margin]:not(svg):not(img), [mt]:not(svg):not(img), [margin-top]:not(svg):not(img), [mr]:not(svg):not(img), [margin-right]:not(svg):not(img), [mb]:not(svg):not(img), [margin-bottom]:not(svg):not(img), [ml]:not(svg):not(img), [margin-left]:not(svg):not(img), [mx]:not(svg):not(img), [my]:not(svg):not(img), [p]:not(svg):not(img), [padding]:not(svg):not(img), [pt]:not(svg):not(img), [padding-top]:not(svg):not(img), [pr]:not(svg):not(img), [padding-right]:not(svg):not(img), [pb]:not(svg):not(img), [padding-bottom]:not(svg):not(img), [pl]:not(svg):not(img), [padding-left]:not(svg):not(img), [px]:not(svg):not(img), [py]:not(svg):not(img), [width]:not(svg):not(img), [font-size]:not(svg):not(img), [color]:not(svg):not(img), [bg]:not(svg):not(img), [background-color]:not(svg):not(img), [font-family]:not(svg):not(img), [text-align]:not(svg):not(img), [line-height]:not(svg):not(img), [font-weight]:not(svg):not(img), [font-style]:not(svg):not(img), [letter-spacing]:not(svg):not(img), [display]:not(svg):not(img), [max-width]:not(svg):not(img), [min-width]:not(svg):not(img), [height]:not(svg):not(img), [max-height]:not(svg):not(img), [min-height]:not(svg):not(img), [size]:not(svg):not(img), [vertical-align]:not(svg):not(img), [align-items]:not(svg):not(img), [justify-content]:not(svg):not(img), [flex-wrap]:not(svg):not(img), [flex-direction]:not(svg):not(img), [flex]:not(svg):not(img), [align-content]:not(svg):not(img), [justify-items]:not(svg):not(img), [justify-self]:not(svg):not(img), [align-self]:not(svg):not(img), [order]:not(svg):not(img), [flex-basis]:not(svg):not(img), [grid-gap]:not(svg):not(img), [grid-row-gap]:not(svg):not(img), [grid-column-gap]:not(svg):not(img), [grid-column]:not(svg):not(img), [grid-row]:not(svg):not(img), [grid-area]:not(svg):not(img), [grid-auto-flow]:not(svg):not(img), [grid-auto-rows]:not(svg):not(img), [grid-auto-columns]:not(svg):not(img), [grid-template-rows]:not(svg):not(img), [grid-template-columns]:not(svg):not(img), [grid-template-areas]:not(svg):not(img), [background]:not(svg):not(img), [background-image]:not(svg):not(img), [background-size]:not(svg):not(img), [background-position]:not(svg):not(img), [background-repeat]:not(svg):not(img), [border]:not(svg):not(img), [border-top]:not(svg):not(img), [border-right]:not(svg):not(img), [border-bottom]:not(svg):not(img), [border-left]:not(svg):not(img), [border-width]:not(svg):not(img), [border-style]:not(svg):not(img), [border-color]:not(svg):not(img), [border-radius]:not(svg):not(img), [box-shadow]:not(svg):not(img), [opacity]:not(svg):not(img), [overflow]:not(svg):not(img), [position]:not(svg):not(img), [z-index]:not(svg):not(img), [top]:not(svg):not(img), [right]:not(svg):not(img), [bottom]:not(svg):not(img), [left]:not(svg):not(img), [text-style]:not(svg):not(img), [colors]:not(svg):not(img), [variant]:not(svg):not(img)')
```


