### PR TITLE
fix: add fixed fontsize to checkbox

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -34,6 +34,7 @@ const CheckboxBorder = styled.div`
   margin-right: ${themeGet('space.2')};
   height: ${rem('20px')};
   width: ${rem('20px')};
+  font-size: ${themeGet('fontSizes.base')};
   background-color: ${themeGet('colors.white')};
   border: ${themeGet('borders.2')};
   border-color: ${themeGet('colors.greys.alto')};


### PR DESCRIPTION
The `font-size` of the checkbox should be fixed, if it is not, it will inherit the containers `font-size` which will potentially change the vertical alignment of the tick svg, which means the checkbox will look incorrect.