### PR TITLE
allow display to be overidden in Button component

### DIFF
--- a/packages/components/src/Button/Button.js
+++ b/packages/components/src/Button/Button.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { darken } from 'polished';
-import { themeGet, space, color, backgroundColor, boxShadow, variant } from 'styled-system';
+import { themeGet, space, color, backgroundColor, boxShadow, display, variant } from 'styled-system';
 import get from 'lodash/get';
 
 const FALLBACK_BG_COLOR = '#000';
@@ -13,7 +13,6 @@ const getBackground = props =>
   get(backgroundColor(props), 'backgroundColor') || get(buttonStyle(props), 'backgroundColor') || FALLBACK_BG_COLOR;
 
 const Button = styled.button`
-  display: inline-block;
   margin: 0;
   padding: ${themeGet('space.3')} ${themeGet('space.6')};
   font-size: ${themeGet('fontSizes.base')};
@@ -31,6 +30,7 @@ const Button = styled.button`
   cursor: pointer;
   appearance: none;
 
+  ${display}
   ${buttonStyle}
   ${space}
   ${color}
@@ -73,6 +73,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   variant: 'default',
+  display: 'inline-block',
 };
 
 export default Button;

--- a/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/packages/components/src/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<OutlineButton /> primary renders correctly 1`] = `
 .emotion-0 {
-  display: inline-block;
   margin: 0;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
@@ -26,6 +25,7 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  display: inline-block;
   color: white;
   background-color: #E40000;
   background-color: transparent;
@@ -66,10 +66,12 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 }
 
 <OutlineButton
+  display="inline-block"
   variant="primary"
 >
   <button
     className="emotion-0 emotion-1"
+    display="inline-block"
   >
     Hello world
   </button>
@@ -78,7 +80,6 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 
 exports[`<OutlineButton /> renders correctly 1`] = `
 .emotion-0 {
-  display: inline-block;
   margin: 0;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
@@ -102,6 +103,7 @@ exports[`<OutlineButton /> renders correctly 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  display: inline-block;
   color: white;
   background-color: #323232;
   background-color: transparent;
@@ -142,10 +144,12 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 }
 
 <OutlineButton
+  display="inline-block"
   variant="default"
 >
   <button
     className="emotion-0 emotion-1"
+    display="inline-block"
   >
     Click here
   </button>
@@ -154,7 +158,6 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 
 exports[`<OutlineButton /> rounded renders correctly 1`] = `
 .emotion-0 {
-  display: inline-block;
   margin: 0;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
@@ -178,6 +181,7 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  display: inline-block;
   background-color: transparent;
   -webkit-transition: none;
   transition: none;
@@ -206,10 +210,12 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 }
 
 <OutlineButton
+  display="inline-block"
   variant="rounded"
 >
   <button
     className="emotion-0 emotion-1"
+    display="inline-block"
   >
     Hello world
   </button>


### PR DESCRIPTION
Even though we have the `block` prop, we have run into trouble when using `as` in conjunction with it, so it would be good if we could set the `display` prop using styled systems helper.