### PR TITLE
feat: add position attributes to Box

### DIFF
--- a/packages/components/src/Box/Box.js
+++ b/packages/components/src/Box/Box.js
@@ -45,9 +45,9 @@ const Box = styled('div', omitProps())`
   ${flex}
   ${position}
   ${zIndex}
-  ${top},
-  ${right},
-  ${bottom},
+  ${top}
+  ${right}
+  ${bottom}
   ${left}
 `;
 

--- a/packages/components/src/Box/Box.js
+++ b/packages/components/src/Box/Box.js
@@ -17,6 +17,10 @@ import {
   flex,
   position,
   zIndex,
+  top,
+  right,
+  bottom,
+  left,
 } from 'styled-system';
 import styled from '@emotion/styled';
 import omitProps from '../omitProps';
@@ -41,6 +45,10 @@ const Box = styled('div', omitProps())`
   ${flex}
   ${position}
   ${zIndex}
+  ${top},
+  ${right},
+  ${bottom},
+  ${left}
 `;
 
 Box.propTypes = {
@@ -62,6 +70,10 @@ Box.propTypes = {
   ...flex.propTypes,
   ...position.propTypes,
   ...zIndex.propTypes,
+  ...top.propTypes,
+  ...right.propTypes,
+  ...bottom.propTypes,
+  ...left.propTypes,
 };
 
 export default Box;

--- a/packages/components/src/Box/README.md
+++ b/packages/components/src/Box/README.md
@@ -37,5 +37,9 @@ This component can be customized with [styled-system](https://jxnblk.com/styled-
 `borderColor`,
 `flexBasis`,
 `flex`,
-`position` &
+`position`,
+`top`,
+`right`,
+`bottom`,
+`left`, &
 `zIndex` [functions](http://jxnblk.com/styled-system/table)

--- a/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__snapshots__/Popover.test.js.snap
@@ -49,7 +49,7 @@ exports[`<Popover /> when popover is closed renders correctly 1`] = `
           >
             <Box>
               <div
-                className="css-1rd3di6-Box emotion-0"
+                className="css-10tnu4p-Box emotion-0"
               >
                 <button
                   disabled={false}


### PR DESCRIPTION
We have `position` on `Box` but are missing positional attributes.

This PR Adds `top`, `right`, `bottom`, `left` to `Box`

![cat-box-giphy](https://user-images.githubusercontent.com/980047/57827232-f6032f80-77e9-11e9-9f08-be9309b953b6.gif)

