### PR TITLE
Tree shakable icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ Import the appropriate font for your theme:
 import '@roo-ui/fonts/ciutadella.css';
 ```
 
+### Icons
+
+SVG icon paths are accessed from your apps theme (`theme.icons[iconName].path`).
+
+A default set of icons are included in the base [qantas theme](https://github.com/hooroo/roo-ui/blob/master/packages/themes/src/qantas.js). 
+
+To add more icons, import them from `@roo-ui/icons` and include them in your apps theme.
+
+**Example: Add more icons to your apps theme**
+
+```jsx
+// my-app/icons.js
+export { arrowUpward, arrowForward } from '@roo-ui/icons';
+
+// my-app/theme.js
+import * as icons from './icons';
+
+export default {
+  ...qantas,
+  icons: {
+    ...qantas.icons,
+    ...icons,
+  },
+};
+```
+
 ### CSS reset
 
 We recommend using [`normalize.css`](http://necolas.github.io/normalize.css/).

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,9 @@
 module.exports = (api) => {
   const isTest = api.env('test');
 
-  const env = isTest ? ['@babel/preset-env', { targets: { node: 'current' } }] : '@babel/preset-env';
+  const env = isTest
+    ? ['@babel/preset-env', { targets: { node: 'current' } }]
+    : ['@babel/preset-env', { modules: false }];
 
   const presets = ['@babel/preset-react', env];
   const plugins = [

--- a/packages/components/src/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__snapshots__/Alert.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -15,16 +15,16 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.errorBackground;
 }
@@ -58,25 +58,25 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="ui.error"
@@ -84,24 +84,22 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="ui.error"
                         name="warning"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="ui.error"
-                          fill="currentcolor"
-                          height={24}
-                          title="warning"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="warning"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="ui.error"
                             fill="currentcolor"
                             height={24}
@@ -109,12 +107,22 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="ui.error"
+                              fill="currentcolor"
+                              height={24}
+                              title="warning"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -125,7 +133,7 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world
@@ -142,12 +150,12 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
 `;
 
 exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -156,16 +164,16 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.infoBackground;
 }
@@ -199,25 +207,25 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="greys.charcoal"
@@ -225,24 +233,22 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="greys.charcoal"
                         name="info"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="greys.charcoal"
-                          fill="currentcolor"
-                          height={24}
-                          title="info"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="info"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="greys.charcoal"
                             fill="currentcolor"
                             height={24}
@@ -250,12 +256,22 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="greys.charcoal"
+                              fill="currentcolor"
+                              height={24}
+                              title="info"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -266,7 +282,7 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world
@@ -283,12 +299,12 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
 `;
 
 exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -297,17 +313,17 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.successBackground;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
@@ -340,25 +356,25 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="ui.success"
@@ -366,24 +382,22 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="ui.success"
                         name="checkCircle"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="ui.success"
-                          fill="currentcolor"
-                          height={24}
-                          title="checkCircle"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="checkCircle"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="ui.success"
                             fill="currentcolor"
                             height={24}
@@ -391,12 +405,22 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="ui.success"
+                              fill="currentcolor"
+                              height={24}
+                              title="checkCircle"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -407,7 +431,7 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world
@@ -424,12 +448,12 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
 `;
 
 exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -438,16 +462,16 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.errorBackground;
 }
@@ -481,25 +505,25 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="ui.error"
@@ -507,24 +531,22 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="ui.error"
                         name="warning"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="ui.error"
-                          fill="currentcolor"
-                          height={24}
-                          title="warning"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="warning"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="ui.error"
                             fill="currentcolor"
                             height={24}
@@ -532,12 +554,22 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="ui.error"
+                              fill="currentcolor"
+                              height={24}
+                              title="warning"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -548,7 +580,7 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world
@@ -565,12 +597,12 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
 `;
 
 exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -579,16 +611,16 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.infoBackground;
 }
@@ -622,25 +654,25 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="greys.charcoal"
@@ -648,24 +680,22 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="greys.charcoal"
                         name="info"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="greys.charcoal"
-                          fill="currentcolor"
-                          height={24}
-                          title="info"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="info"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="greys.charcoal"
                             fill="currentcolor"
                             height={24}
@@ -673,12 +703,22 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="greys.charcoal"
+                              fill="currentcolor"
+                              height={24}
+                              title="info"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -689,7 +729,7 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world
@@ -706,12 +746,12 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
 `;
 
 exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
-.emotion-13 {
+.emotion-15 {
   padding-left: 32px;
   padding-right: 32px;
 }
 
-.emotion-11 {
+.emotion-13 {
   padding-top: 32px;
   padding-bottom: 32px;
   display: -webkit-box;
@@ -720,17 +760,17 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
   display: flex;
 }
 
-.emotion-9 {
+.emotion-11 {
   margin-bottom: 0;
   text-align: left;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-bottom: 16px;
   background-color: ui.successBackground;
 }
 
-.emotion-7 {
+.emotion-9 {
   padding-right: 16px;
 }
 
@@ -763,25 +803,25 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
       mb={3}
     >
       <div
-        className="emotion-15 emotion-8"
+        className="emotion-17 emotion-10"
       >
         <Box
           px={4}
         >
           <div
-            className="emotion-13 emotion-8"
+            className="emotion-15 emotion-10"
           >
             <Flex
               py={4}
             >
               <div
-                className="emotion-11 emotion-12"
+                className="emotion-13 emotion-14"
               >
                 <Box
                   pr={3}
                 >
                   <div
-                    className="emotion-7 emotion-8"
+                    className="emotion-9 emotion-10"
                   >
                     <Icon
                       color="ui.success"
@@ -789,24 +829,22 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                       size={24}
                       title={null}
                     >
-                      <Base
+                      <WithTheme(Component)
                         className="emotion-3 emotion-0"
                         color="ui.success"
                         name="checkCircle"
                         size={24}
                         title={null}
                       >
-                        <StyledSvg
+                        <Component
                           className="emotion-3 emotion-0"
                           color="ui.success"
-                          fill="currentcolor"
-                          height={24}
-                          title="checkCircle"
-                          viewBox="0 0 24 24"
-                          width={24}
+                          name="checkCircle"
+                          size={24}
+                          title={null}
                         >
-                          <svg
-                            className="emotion-0 emotion-1 emotion-2"
+                          <StyledSvg
+                            className="emotion-3 emotion-0"
                             color="ui.success"
                             fill="currentcolor"
                             height={24}
@@ -814,12 +852,22 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                             viewBox="0 0 24 24"
                             width={24}
                           >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                            />
-                          </svg>
-                        </StyledSvg>
-                      </Base>
+                            <svg
+                              className="emotion-0 emotion-1 emotion-2"
+                              color="ui.success"
+                              fill="currentcolor"
+                              height={24}
+                              title="checkCircle"
+                              viewBox="0 0 24 24"
+                              width={24}
+                            >
+                              <path
+                                d={null}
+                              />
+                            </svg>
+                          </StyledSvg>
+                        </Component>
+                      </WithTheme(Component)>
                     </Icon>
                   </div>
                 </Box>
@@ -830,7 +878,7 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                   textStyle="text"
                 >
                   <span
-                    className="emotion-9 emotion-10"
+                    className="emotion-11 emotion-12"
                     hidden={false}
                   >
                     Hello world

--- a/packages/components/src/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/packages/components/src/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Checkbox /> renders correctly 1`] = `
-.emotion-11 {
+.emotion-13 {
   display: inline-block;
   position: relative;
 }
@@ -57,7 +57,7 @@ input:checked ~ .emotion-5 {
 <Checkbox>
   <CheckboxWrapper>
     <div
-      className="emotion-11 emotion-12"
+      className="emotion-13 emotion-14"
     >
       <CheckboxInput
         type="checkbox"
@@ -77,34 +77,41 @@ input:checked ~ .emotion-5 {
         size={24}
         title={null}
       >
-        <Base
+        <WithTheme(Component)
           className="emotion-7 emotion-4"
           name="done"
           size={24}
           title={null}
         >
-          <StyledSvg
+          <Component
             className="emotion-7 emotion-4"
-            fill="currentcolor"
-            height={24}
-            title="done"
-            viewBox="0 0 24 24"
-            width={24}
+            name="done"
+            size={24}
+            title={null}
           >
-            <svg
-              className="emotion-4 emotion-5 emotion-6"
+            <StyledSvg
+              className="emotion-7 emotion-4"
               fill="currentcolor"
               height={24}
               title="done"
               viewBox="0 0 24 24"
               width={24}
             >
-              <path
-                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-              />
-            </svg>
-          </StyledSvg>
-        </Base>
+              <svg
+                className="emotion-4 emotion-5 emotion-6"
+                fill="currentcolor"
+                height={24}
+                title="done"
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d={null}
+                />
+              </svg>
+            </StyledSvg>
+          </Component>
+        </WithTheme(Component)>
       </CheckboxIcon>
     </div>
   </CheckboxWrapper>
@@ -112,7 +119,7 @@ input:checked ~ .emotion-5 {
 `;
 
 exports[`<Checkbox /> when checked renders correctly 1`] = `
-.emotion-11 {
+.emotion-13 {
   display: inline-block;
   position: relative;
 }
@@ -170,7 +177,7 @@ input:checked ~ .emotion-5 {
 >
   <CheckboxWrapper>
     <div
-      className="emotion-11 emotion-12"
+      className="emotion-13 emotion-14"
     >
       <CheckboxInput
         defaultChecked={true}
@@ -192,34 +199,41 @@ input:checked ~ .emotion-5 {
         size={24}
         title={null}
       >
-        <Base
+        <WithTheme(Component)
           className="emotion-7 emotion-4"
           name="done"
           size={24}
           title={null}
         >
-          <StyledSvg
+          <Component
             className="emotion-7 emotion-4"
-            fill="currentcolor"
-            height={24}
-            title="done"
-            viewBox="0 0 24 24"
-            width={24}
+            name="done"
+            size={24}
+            title={null}
           >
-            <svg
-              className="emotion-4 emotion-5 emotion-6"
+            <StyledSvg
+              className="emotion-7 emotion-4"
               fill="currentcolor"
               height={24}
               title="done"
               viewBox="0 0 24 24"
               width={24}
             >
-              <path
-                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-              />
-            </svg>
-          </StyledSvg>
-        </Base>
+              <svg
+                className="emotion-4 emotion-5 emotion-6"
+                fill="currentcolor"
+                height={24}
+                title="done"
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d={null}
+                />
+              </svg>
+            </StyledSvg>
+          </Component>
+        </WithTheme(Component)>
       </CheckboxIcon>
     </div>
   </CheckboxWrapper>
@@ -227,7 +241,7 @@ input:checked ~ .emotion-5 {
 `;
 
 exports[`<Checkbox /> when disabled renders correctly 1`] = `
-.emotion-11 {
+.emotion-13 {
   display: inline-block;
   position: relative;
 }
@@ -285,7 +299,7 @@ input:checked ~ .emotion-5 {
 >
   <CheckboxWrapper>
     <div
-      className="emotion-11 emotion-12"
+      className="emotion-13 emotion-14"
     >
       <CheckboxInput
         disabled={true}
@@ -307,34 +321,41 @@ input:checked ~ .emotion-5 {
         size={24}
         title={null}
       >
-        <Base
+        <WithTheme(Component)
           className="emotion-7 emotion-4"
           name="done"
           size={24}
           title={null}
         >
-          <StyledSvg
+          <Component
             className="emotion-7 emotion-4"
-            fill="currentcolor"
-            height={24}
-            title="done"
-            viewBox="0 0 24 24"
-            width={24}
+            name="done"
+            size={24}
+            title={null}
           >
-            <svg
-              className="emotion-4 emotion-5 emotion-6"
+            <StyledSvg
+              className="emotion-7 emotion-4"
               fill="currentcolor"
               height={24}
               title="done"
               viewBox="0 0 24 24"
               width={24}
             >
-              <path
-                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-              />
-            </svg>
-          </StyledSvg>
-        </Base>
+              <svg
+                className="emotion-4 emotion-5 emotion-6"
+                fill="currentcolor"
+                height={24}
+                title="done"
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d={null}
+                />
+              </svg>
+            </StyledSvg>
+          </Component>
+        </WithTheme(Component)>
       </CheckboxIcon>
     </div>
   </CheckboxWrapper>

--- a/packages/components/src/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/packages/components/src/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CalendarNav /> renders correctly 1`] = `
-.emotion-18 {
+.emotion-22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,7 +15,7 @@ exports[`<CalendarNav /> renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-7 {
+.emotion-9 {
   border: none;
   margin: 0;
   padding: 0;
@@ -31,12 +31,12 @@ exports[`<CalendarNav /> renders correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-7:hover,
-.emotion-7:focus {
+.emotion-9:hover,
+.emotion-9:focus {
   outline: none;
 }
 
-.emotion-7:disabled {
+.emotion-9:disabled {
   cursor: not-allowed;
   box-shadow: none;
 }
@@ -69,7 +69,7 @@ exports[`<CalendarNav /> renders correctly 1`] = `
 >
   <Wrapper>
     <div
-      className="emotion-18 emotion-19"
+      className="emotion-22 emotion-23"
     >
       <Button
         as="button"
@@ -77,7 +77,7 @@ exports[`<CalendarNav /> renders correctly 1`] = `
         type="button"
       >
         <button
-          className="emotion-7 emotion-8"
+          className="emotion-9 emotion-10"
           onClick={[MockFunction]}
           type="button"
         >
@@ -86,34 +86,41 @@ exports[`<CalendarNav /> renders correctly 1`] = `
             size={24}
             title={null}
           >
-            <Base
+            <WithTheme(Component)
               className="emotion-3 emotion-0"
               name="chevronLeft"
               size={24}
               title={null}
             >
-              <StyledSvg
+              <Component
                 className="emotion-3 emotion-0"
-                fill="currentcolor"
-                height={24}
-                title="chevronLeft"
-                viewBox="0 0 24 24"
-                width={24}
+                name="chevronLeft"
+                size={24}
+                title={null}
               >
-                <svg
-                  className="emotion-0 emotion-1 emotion-2"
+                <StyledSvg
+                  className="emotion-3 emotion-0"
                   fill="currentcolor"
                   height={24}
                   title="chevronLeft"
                   viewBox="0 0 24 24"
                   width={24}
                 >
-                  <path
-                    d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
-                  />
-                </svg>
-              </StyledSvg>
-            </Base>
+                  <svg
+                    className="emotion-0 emotion-1 emotion-2"
+                    fill="currentcolor"
+                    height={24}
+                    title="chevronLeft"
+                    viewBox="0 0 24 24"
+                    width={24}
+                  >
+                    <path
+                      d={null}
+                    />
+                  </svg>
+                </StyledSvg>
+              </Component>
+            </WithTheme(Component)>
           </Icon>
         </button>
       </Button>
@@ -123,7 +130,7 @@ exports[`<CalendarNav /> renders correctly 1`] = `
         type="button"
       >
         <button
-          className="emotion-7 emotion-8"
+          className="emotion-9 emotion-10"
           onClick={[MockFunction]}
           type="button"
         >
@@ -132,34 +139,41 @@ exports[`<CalendarNav /> renders correctly 1`] = `
             size={24}
             title={null}
           >
-            <Base
+            <WithTheme(Component)
               className="emotion-3 emotion-0"
               name="chevronRight"
               size={24}
               title={null}
             >
-              <StyledSvg
+              <Component
                 className="emotion-3 emotion-0"
-                fill="currentcolor"
-                height={24}
-                title="chevronRight"
-                viewBox="0 0 24 24"
-                width={24}
+                name="chevronRight"
+                size={24}
+                title={null}
               >
-                <svg
-                  className="emotion-0 emotion-1 emotion-2"
+                <StyledSvg
+                  className="emotion-3 emotion-0"
                   fill="currentcolor"
                   height={24}
                   title="chevronRight"
                   viewBox="0 0 24 24"
                   width={24}
                 >
-                  <path
-                    d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                  />
-                </svg>
-              </StyledSvg>
-            </Base>
+                  <svg
+                    className="emotion-0 emotion-1 emotion-2"
+                    fill="currentcolor"
+                    height={24}
+                    title="chevronRight"
+                    viewBox="0 0 24 24"
+                    width={24}
+                  >
+                    <path
+                      d={null}
+                    />
+                  </svg>
+                </StyledSvg>
+              </Component>
+            </WithTheme(Component)>
           </Icon>
         </button>
       </Button>

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -1,29 +1,28 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { withTheme } from 'emotion-theming';
 import { space, color } from 'styled-system';
 import PropTypes from 'prop-types';
-import paths from '@roo-ui/icons';
 
 const StyledSvg = styled.svg``;
 
-
-const Base = ({
-  name, title, size, ...props
+const Base = withTheme(({
+  name, title, size, theme, ...props
 }) => (
-  <StyledSvg
-    {...props}
-    viewBox="0 0 24 24"
-    width={size}
-    height={size}
-    title={title || name}
-    fill="currentcolor"
-  >
-    <path d={paths[name].path} />
-  </StyledSvg>
-);
+    <StyledSvg
+      {...props}
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      title={title || name}
+      fill="currentcolor"
+    >
+      <path d={theme.icons[name].path} />
+    </StyledSvg>
+  ));
 
 Base.propTypes = {
-  name: PropTypes.oneOf(Object.keys(paths)),
+  name: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   title: PropTypes.string,
 };

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -3,23 +3,26 @@ import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
 import { space, color } from 'styled-system';
 import PropTypes from 'prop-types';
-import memoize from 'lodash/memoize';
 
-const getSvgPath = memoize((theme, name) => {
+const IS_TEST = process.env.NODE_ENV === 'test';
+
+const getSvgPath = (theme, name) => {
   if (!theme || !theme.icons) {
-    console.error('Icon must be rendered under ThemeProvider'); // eslint-disable-line no-console
+    // eslint-disable-next-line no-console
+    if (!IS_TEST) console.error('Icon must be rendered under ThemeProvider');
     return null;
   }
 
   const icon = theme.icons[name];
 
   if (!icon) {
-    console.error(`Icon "${name}" not found in theme`); // eslint-disable-line no-console
+    // eslint-disable-next-line no-console
+    console.error(`Icon "${name}" not found in theme`);
     return null;
   }
 
   return icon.path;
-});
+};
 
 const StyledSvg = styled.svg``;
 

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -9,17 +9,17 @@ const StyledSvg = styled.svg``;
 const Base = withTheme(({
   name, title, size, theme, ...props
 }) => (
-    <StyledSvg
-      {...props}
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      title={title || name}
-      fill="currentcolor"
-    >
-      <path d={theme.icons[name].path} />
-    </StyledSvg>
-  ));
+  <StyledSvg
+    {...props}
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    title={title || name}
+    fill="currentcolor"
+  >
+    <path d={theme.icons[name].path} />
+  </StyledSvg>
+));
 
 Base.propTypes = {
   name: PropTypes.string,

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -4,6 +4,18 @@ import { withTheme } from 'emotion-theming';
 import { space, color } from 'styled-system';
 import PropTypes from 'prop-types';
 
+const getSvgPath = (theme, name) => {
+  const icon = theme.icons[name];
+
+  if (icon) {
+    return icon.path;
+  }
+
+  console.error(`Icon "${name}" not found in theme`); // eslint-disable-line no-console
+
+  return null;
+};
+
 const StyledSvg = styled.svg``;
 
 const Base = withTheme(({
@@ -17,7 +29,7 @@ const Base = withTheme(({
     title={title || name}
     fill="currentcolor"
   >
-    <path d={theme.icons[name].path} />
+    <path d={getSvgPath(theme, name)} />
   </StyledSvg>
 ));
 

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -3,18 +3,23 @@ import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
 import { space, color } from 'styled-system';
 import PropTypes from 'prop-types';
+import memoize from 'lodash/memoize';
 
-const getSvgPath = (theme, name) => {
-  const icon = theme.icons[name];
-
-  if (icon) {
-    return icon.path;
+const getSvgPath = memoize((theme, name) => {
+  if (!theme || !theme.icons) {
+    console.error('Icon must be rendered under ThemeProvider'); // eslint-disable-line no-console
+    return null;
   }
 
-  console.error(`Icon "${name}" not found in theme`); // eslint-disable-line no-console
+  const icon = theme.icons[name];
 
-  return null;
-};
+  if (!icon) {
+    console.error(`Icon "${name}" not found in theme`); // eslint-disable-line no-console
+    return null;
+  }
+
+  return icon.path;
+});
 
 const StyledSvg = styled.svg``;
 

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 const IS_TEST = process.env.NODE_ENV === 'test';
 
-const getSvgPath = (theme, name) => {
+const getSvgPathFromTheme = (theme, name) => {
   if (!theme || !theme.icons) {
     // eslint-disable-next-line no-console
     if (!IS_TEST) console.error('Icon must be rendered under ThemeProvider');
@@ -37,7 +37,7 @@ const Base = withTheme(({
     title={title || name}
     fill="currentcolor"
   >
-    <path d={getSvgPath(theme, name)} />
+    <path d={getSvgPathFromTheme(theme, name)} />
   </StyledSvg>
 ));
 

--- a/packages/components/src/Icon/Icon.story.js
+++ b/packages/components/src/Icon/Icon.story.js
@@ -1,17 +1,21 @@
 import styled from '@emotion/styled';
+import { ThemeProvider, withTheme } from 'emotion-theming';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
 import map from 'lodash/map';
 import groupBy from 'lodash/groupBy';
-import paths from '@roo-ui/icons';
+import { qantas } from '@roo-ui/themes';
+import * as allIcons from '@roo-ui/icons';
 
 import { Box, Paragraph } from '..';
 import Icon from '.';
 import README from './README.md';
 
+const themeWithAllIcons = { ...qantas, icons: allIcons };
+
 const groupedPaths = groupBy(
-  map(paths, ({ category }, name) => ({ category, name })),
+  map(allIcons, ({ category }, name) => ({ category, name })),
   'category',
 );
 
@@ -27,34 +31,47 @@ const Caption = styled(Paragraph)`
   text-overflow: ellipsis;
 `;
 
-const renderIcons = group => () => (
+const IconsInTheme = withTheme(({ theme }) => (
   <Grid>
-    {groupedPaths[group].map(({ name }) => (
+    {map(theme.icons, (_, name) => (
       <Box p={4} key={name}>
         <Icon color="greys.steel" size={48} name={name} />
         <Caption title={name} fontSize="xs" color="greys.steel">{name}</Caption>
       </Box>
     ))}
   </Grid>
+));
+
+const renderIconsInCategory = group => () => (
+  <Grid>
+    <ThemeProvider theme={themeWithAllIcons}>
+      {groupedPaths[group].map(({ name }) => (
+        <Box p={4} key={name}>
+          <Icon color="greys.steel" size={48} name={name} />
+          <Caption title={name} fontSize="xs" color="greys.steel">{name}</Caption>
+        </Box>
+      ))}
+    </ThemeProvider>
+  </Grid>
 );
 
 storiesOf('Components|Icon', module)
   .addDecorator(withDocs(README))
-  .add('action', renderIcons('action'))
-  .add('alert', renderIcons('alert'))
-  .add('av', renderIcons('av'))
-  .add('communication', renderIcons('communication'))
-  .add('content', renderIcons('content'))
-  .add('device', renderIcons('device'))
-  .add('editor', renderIcons('editor'))
-  .add('file', renderIcons('file'))
-  .add('hardware', renderIcons('hardware'))
-  .add('image', renderIcons('image'))
-  .add('maps', renderIcons('maps'))
-  .add('navigation', renderIcons('navigation'))
-  .add('notification', renderIcons('notification'))
-  .add('places', renderIcons('places'))
-  .add('rating', renderIcons('rating'))
-  .add('social', renderIcons('social'))
-  .add('toggle', renderIcons('toggle'))
-  .add('qantas', renderIcons('qantas'));
+  .add('default icons', () => <IconsInTheme />)
+  .add('alert', renderIconsInCategory('alert'))
+  .add('av', renderIconsInCategory('av'))
+  .add('communication', renderIconsInCategory('communication'))
+  .add('content', renderIconsInCategory('content'))
+  .add('device', renderIconsInCategory('device'))
+  .add('editor', renderIconsInCategory('editor'))
+  .add('file', renderIconsInCategory('file'))
+  .add('hardware', renderIconsInCategory('hardware'))
+  .add('image', renderIconsInCategory('image'))
+  .add('maps', renderIconsInCategory('maps'))
+  .add('navigation', renderIconsInCategory('navigation'))
+  .add('notification', renderIconsInCategory('notification'))
+  .add('places', renderIconsInCategory('places'))
+  .add('rating', renderIconsInCategory('rating'))
+  .add('social', renderIconsInCategory('social'))
+  .add('toggle', renderIconsInCategory('toggle'))
+  .add('qantas', renderIconsInCategory('qantas'));

--- a/packages/components/src/Icon/Icon.test.js
+++ b/packages/components/src/Icon/Icon.test.js
@@ -1,22 +1,52 @@
 import React from 'react';
-import { qantas as theme } from '@roo-ui/themes';
-import { mountWithTheme } from '@roo-ui/test-utils';
+import { mount } from 'enzyme';
+import { qantas, ThemeProvider } from '@roo-ui/themes';
 import { axe } from 'jest-axe';
 
 import Icon from '.';
 
 describe('<Icon />', () => {
   let wrapper;
+  let props;
 
-  beforeEach(() => {
-    wrapper = mountWithTheme(<Icon name="hotel" />, theme);
+  const render = () => {
+    wrapper = mount(<ThemeProvider theme={qantas}><Icon {...props} /></ThemeProvider>).find(Icon);
+  };
+
+  describe('when passed icon name in theme', () => {
+    beforeEach(() => {
+      props = { name: 'hotel' };
+      render();
+    });
+
+    it('renders correctly', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('has no accessibility errors', async () => {
+      expect(await axe(wrapper.html())).toHaveNoViolations();
+    });
   });
 
-  it('renders correctly', () => {
-    expect(wrapper).toMatchSnapshot();
-  });
+  describe('when passed icon name not in theme', () => {
+    let consoleSpy;
 
-  it('has no accessibility errors', async () => {
-    expect(await axe(wrapper.html())).toHaveNoViolations();
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      props = { name: '_def_not_in_theme' };
+      render();
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('renders svg with null path', () => {
+      expect(wrapper.find('svg path').prop('d')).toBe(null);
+    });
+
+    it('logs error to console', () => {
+      expect(consoleSpy).toHaveBeenCalledWith('Icon "_def_not_in_theme" not found in theme');
+    });
   });
 });

--- a/packages/components/src/Icon/__snapshots__/Icon.test.js.snap
+++ b/packages/components/src/Icon/__snapshots__/Icon.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Icon /> renders correctly 1`] = `
+exports[`<Icon /> when passed icon name in theme renders correctly 1`] = `
 .emotion-3 {
   vertical-align: middle;
   -webkit-flex: none;
@@ -20,33 +20,40 @@ exports[`<Icon /> renders correctly 1`] = `
   size={24}
   title={null}
 >
-  <Base
+  <WithTheme(Component)
     className="emotion-3 emotion-0"
     name="hotel"
     size={24}
     title={null}
   >
-    <StyledSvg
+    <Component
       className="emotion-3 emotion-0"
-      fill="currentcolor"
-      height={24}
-      title="hotel"
-      viewBox="0 0 24 24"
-      width={24}
+      name="hotel"
+      size={24}
+      title={null}
     >
-      <svg
-        className="emotion-0 emotion-1 emotion-2"
+      <StyledSvg
+        className="emotion-3 emotion-0"
         fill="currentcolor"
         height={24}
         title="hotel"
         viewBox="0 0 24 24"
         width={24}
       >
-        <path
-          d="M7 13c1.66 0 3-1.34 3-3S8.66 7 7 7s-3 1.34-3 3 1.34 3 3 3zm12-6h-8v7H3V5H1v15h2v-3h18v3h2v-9c0-2.21-1.79-4-4-4z"
-        />
-      </svg>
-    </StyledSvg>
-  </Base>
+        <svg
+          className="emotion-0 emotion-1 emotion-2"
+          fill="currentcolor"
+          height={24}
+          title="hotel"
+          viewBox="0 0 24 24"
+          width={24}
+        >
+          <path
+            d="M7 13c1.66 0 3-1.34 3-3S8.66 7 7 7s-3 1.34-3 3 1.34 3 3 3zm12-6h-8v7H3V5H1v15h2v-3h18v3h2v-9c0-2.21-1.79-4-4-4z"
+          />
+        </svg>
+      </StyledSvg>
+    </Component>
+  </WithTheme(Component)>
 </Icon>
 `;

--- a/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/packages/components/src/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -42,7 +42,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   display: none;
 }
 
-.emotion-14 {
+.emotion-16 {
   position: relative;
 }
 
@@ -127,7 +127,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   display: none;
 }
 
-.emotion-12 {
+.emotion-14 {
   border: none;
   margin: 0;
   padding: 0;
@@ -149,7 +149,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   text-decoration: underline;
 }
 
-.emotion-12:focus {
+.emotion-14:focus {
   outline: none;
 }
 
@@ -177,7 +177,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
   >
     <Wrapper>
       <div
-        className="emotion-14 emotion-15"
+        className="emotion-16 emotion-17"
       >
         <PasswordInput__Input
           bg="white"
@@ -204,7 +204,7 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
           type="button"
         >
           <button
-            className="emotion-12 emotion-13"
+            className="emotion-14 emotion-15"
             onClick={[Function]}
             type="button"
           >
@@ -214,36 +214,44 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
               size={22}
               title={null}
             >
-              <Base
+              <WithTheme(Component)
                 className="emotion-8 emotion-5"
                 mr={2}
                 name="visibility"
                 size={22}
                 title={null}
               >
-                <StyledSvg
+                <Component
                   className="emotion-8 emotion-5"
-                  fill="currentcolor"
-                  height={22}
                   mr={2}
-                  title="visibility"
-                  viewBox="0 0 24 24"
-                  width={22}
+                  name="visibility"
+                  size={22}
+                  title={null}
                 >
-                  <svg
-                    className="emotion-5 emotion-6 emotion-7"
+                  <StyledSvg
+                    className="emotion-8 emotion-5"
                     fill="currentcolor"
                     height={22}
+                    mr={2}
                     title="visibility"
                     viewBox="0 0 24 24"
                     width={22}
                   >
-                    <path
-                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                    />
-                  </svg>
-                </StyledSvg>
-              </Base>
+                    <svg
+                      className="emotion-5 emotion-6 emotion-7"
+                      fill="currentcolor"
+                      height={22}
+                      title="visibility"
+                      viewBox="0 0 24 24"
+                      width={22}
+                    >
+                      <path
+                        d={null}
+                      />
+                    </svg>
+                  </StyledSvg>
+                </Component>
+              </WithTheme(Component)>
             </Icon>
             Show
           </button>
@@ -296,7 +304,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   display: none;
 }
 
-.emotion-14 {
+.emotion-16 {
   position: relative;
 }
 
@@ -381,7 +389,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   display: none;
 }
 
-.emotion-12 {
+.emotion-14 {
   border: none;
   margin: 0;
   padding: 0;
@@ -403,7 +411,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   text-decoration: underline;
 }
 
-.emotion-12:focus {
+.emotion-14:focus {
   outline: none;
 }
 
@@ -431,7 +439,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
   >
     <Wrapper>
       <div
-        className="emotion-14 emotion-15"
+        className="emotion-16 emotion-17"
       >
         <PasswordInput__Input
           bg="white"
@@ -458,7 +466,7 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
           type="button"
         >
           <button
-            className="emotion-12 emotion-13"
+            className="emotion-14 emotion-15"
             onClick={[Function]}
             type="button"
           >
@@ -468,36 +476,44 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
               size={22}
               title={null}
             >
-              <Base
+              <WithTheme(Component)
                 className="emotion-8 emotion-5"
                 mr={2}
                 name="visibilityOff"
                 size={22}
                 title={null}
               >
-                <StyledSvg
+                <Component
                   className="emotion-8 emotion-5"
-                  fill="currentcolor"
-                  height={22}
                   mr={2}
-                  title="visibilityOff"
-                  viewBox="0 0 24 24"
-                  width={22}
+                  name="visibilityOff"
+                  size={22}
+                  title={null}
                 >
-                  <svg
-                    className="emotion-5 emotion-6 emotion-7"
+                  <StyledSvg
+                    className="emotion-8 emotion-5"
                     fill="currentcolor"
                     height={22}
+                    mr={2}
                     title="visibilityOff"
                     viewBox="0 0 24 24"
                     width={22}
                   >
-                    <path
-                      d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46A11.804 11.804 0 0 0 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"
-                    />
-                  </svg>
-                </StyledSvg>
-              </Base>
+                    <svg
+                      className="emotion-5 emotion-6 emotion-7"
+                      fill="currentcolor"
+                      height={22}
+                      title="visibilityOff"
+                      viewBox="0 0 24 24"
+                      width={22}
+                    >
+                      <path
+                        d={null}
+                      />
+                    </svg>
+                  </StyledSvg>
+                </Component>
+              </WithTheme(Component)>
             </Icon>
             Hide
           </button>

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,17 +3,21 @@
   "version": "0.61.4",
   "license": "MIT",
   "main": "dist/index.js",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist && node ./parseIcons.js",
+    "build": "node ./parseIcons.js",
     "build:watch": "onchange 'src/**/*.svg' -i -v -- yarn run build"
   },
   "devDependencies": {
+    "fs-extra": "^8.0.1",
     "glob": "^7.1.2",
+    "is-var-name": "^2.0.0",
     "onchange": "^4.0.0",
+    "prettier": "^1.17.1",
     "svgi": "^1.1.0",
     "svgo": "^1.0.5"
   }

--- a/packages/icons/parseIcons.js
+++ b/packages/icons/parseIcons.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 const fs = require('fs-extra');
-const path = require('path');
+const { basename, dirname } = require('path');
 const SVGI = require('svgi');
 const camelCase = require('lodash/camelCase');
 const last = require('lodash/last');
@@ -15,23 +16,16 @@ const isValidIconName = (name) => {
   if (!isVarName(name)) {
     return false;
   }
-  return isVarName(name) && !['public'].includes(name)
+  return isVarName(name) && !['public'].includes(name);
 };
-
-const readIcons = dir =>
-  glob.sync(dir).map(file => ({
-    key: camelCase(path.basename(file, '.svg')),
-    category: camelCase(last(path.dirname(file).split('/'))),
-    path: svgToPath(file),
-  }));
 
 const flattenChildren = (a, b) => {
   const children = b.children.reduce(flattenChildren, []);
   return [...a, b, ...children];
 };
 
-const svgToPath = svgFile => {
-  const svg = fs.readFileSync(svgFile, 'utf8')
+const svgToPath = (svgFile) => {
+  const svg = fs.readFileSync(svgFile, 'utf8');
   const { nodes } = new SVGI(svg).report();
   return nodes.children
     .reduce(flattenChildren, [])
@@ -40,6 +34,13 @@ const svgToPath = svgFile => {
     .join(' ');
 };
 
+const readIcons = dir =>
+  glob.sync(dir).map(file => ({
+    key: camelCase(basename(file, '.svg')),
+    category: camelCase(last(dirname(file).split('/'))),
+    path: svgToPath(file),
+  }));
+
 const iconToExport = ({ key, category, path }) => `export const ${key} = ${JSON.stringify({ category, path })};\n`;
 
 const uniqueByKey = fp.uniqBy('key');
@@ -47,11 +48,11 @@ const uniqueByKey = fp.uniqBy('key');
 const partitionByValidName = fp.partition(icon => isValidIconName(icon.key));
 
 const build = () => {
-  fs.emptyDirSync(path.dirname(filepath));
+  fs.emptyDirSync(dirname(filepath));
   const allIcons = uniqueByKey(readIcons(srcDir));
   const [validIcons, invalidIcons] = partitionByValidName(allIcons);
 
-  console.log(`Skipping icons with invalid variable names: [${invalidIcons.map(icon => JSON.stringify(icon.key)).join(', ')}]`)
+  console.log(`Skipping icons with invalid variable names: [${invalidIcons.map(icon => JSON.stringify(icon.key)).join(', ')}]`);
 
   const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'));
   fs.writeFileSync(filepath, moduleContents, 'utf8');

--- a/packages/icons/parseIcons.js
+++ b/packages/icons/parseIcons.js
@@ -54,7 +54,7 @@ const build = () => {
 
   console.log(`Skipping icons with invalid variable names: [${invalidIcons.map(icon => JSON.stringify(icon.key)).join(', ')}]`);
 
-  const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'));
+  const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'), { parser: 'babel' });
   fs.writeFileSync(filepath, moduleContents, 'utf8');
 };
 

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -1,1 +1,0 @@
-export { default } from './paths.json'; // eslint-disable-line import/no-unresolved

--- a/packages/themes/src/defaultIcons.js
+++ b/packages/themes/src/defaultIcons.js
@@ -1,0 +1,29 @@
+export {
+    hotel,
+    close,
+    done,
+    chevronLeft,
+    chevronRight,
+    visibilityOff,
+    visibility,
+    expandMore,
+    star,
+    starHalf,
+    starBorder,
+    circle,
+    circleHalf,
+    circleBorder,
+} from '@roo-ui/icons';
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/packages/themes/src/defaultIcons.js
+++ b/packages/themes/src/defaultIcons.js
@@ -1,4 +1,7 @@
 export {
+  info,
+  warning,
+  checkCircle,
   hotel,
   close,
   done,

--- a/packages/themes/src/defaultIcons.js
+++ b/packages/themes/src/defaultIcons.js
@@ -1,29 +1,17 @@
 export {
-    hotel,
-    close,
-    done,
-    chevronLeft,
-    chevronRight,
-    visibilityOff,
-    visibility,
-    expandMore,
-    star,
-    starHalf,
-    starBorder,
-    circle,
-    circleHalf,
-    circleBorder,
+  hotel,
+  close,
+  done,
+  chevronLeft,
+  chevronRight,
+  visibilityOff,
+  visibility,
+  expandMore,
+  star,
+  starHalf,
+  starBorder,
+  circle,
+  circleHalf,
+  circleBorder,
 } from '@roo-ui/icons';
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -1,5 +1,6 @@
 import { rem } from 'polished';
 import range from 'lodash/range';
+import * as icons from './defaultIcons'
 
 const brand = {
   primary: '#E40000',
@@ -237,6 +238,7 @@ const opacity = {
 };
 
 export default {
+  icons,
   gutters,
   colors,
   breakpoints,

--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -1,6 +1,6 @@
 import { rem } from 'polished';
 import range from 'lodash/range';
-import * as icons from './defaultIcons'
+import * as icons from './defaultIcons';
 
 const brand = {
   primary: '#E40000',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,6 +5498,15 @@ fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
+  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -6709,6 +6718,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-var-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-var-name/-/is-var-name-2.0.0.tgz#28cad24d1e4021640bc54668b2de84a9f9b0d776"
+  integrity sha512-U+7mpdfaV4Qz2hDNy1Vt7TjWwdIp6br/w7CUlTnyMdsJq+IOSZrh+RsJNlSSckPAnTllhWxpiqC7VSxVTbcr2Q==
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -9212,6 +9226,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Export svg icon paths as es-module, allowing them to be treeshaked by consuming apps.

If you need more icons than what's included in `packages/themes/src/defaultIcons.js`. Add them to your apps theme:

```js
// my-app/icons.js
export { arrowUpward, arrowForward } from '@roo-ui/icons';

// my-app/theme.js
import * as icons from './icons';

export default {
  ...qantas,
  icons: {
    ...qantas.icons,
    ...icons,
  },
};
```