### PR TITLE
make label line-height consistent with text

### DIFF
--- a/packages/themes/src/qantas.js
+++ b/packages/themes/src/qantas.js
@@ -89,6 +89,7 @@ const textStyles = {
   },
   label: {
     fontSize: fontSizes.sm,
+    lineHeight: lineHeights.loose,
     fontWeight: fontWeights.bold,
     color: colors.greys.charcoal,
   },


### PR DESCRIPTION
Makes the label line height consistent with text line height. Label currently defaults to the base-line height of 1.35 which is subtly different to that of Text which is 1.5. This makes aligning these two elements vertically along a horizontal axis harder than it could be.

Happy to hear reasons why this is a bad idea but hoping it won't impact any other app.