### PR TITLE
Create both esm & cjs builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,15 @@
 module.exports = (api) => {
   const isTest = api.env('test');
 
-  const env = isTest
-    ? ['@babel/preset-env', { targets: { node: 'current' } }]
-    : ['@babel/preset-env', { modules: false }];
+  let env;
+
+  if (isTest) {
+    env = ['@babel/preset-env', { targets: { node: 'current' } }];
+  } else if (process.env.ESM_BUILD) {
+    env = ['@babel/preset-env', { modules: false }];
+  } else {
+    env = ['@babel/preset-env'];
+  }
 
   const presets = ['@babel/preset-react', env];
   const plugins = [

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
     "babel-plugin-emotion": "^10.0.9",
+    "concurrently": "^4.1.1",
     "emotion-theming": "^10.0.10",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -2,12 +2,18 @@
   "name": "@roo-ui/assets",
   "version": "0.58.10",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist --copy-files"
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel --copy-files --root-mode upward src -d dist/cjs",
+    "build:esm": "ESM_BUILD=1 babel --copy-files --root-mode upward src -d dist/esm",
+    "build:cjs:watch": "yarn run build:cjs --watch",
+    "build:esm:watch": "yarn run build:esm --watch",
+    "build:watch": "concurrently --kill-others yarn:build:cjs:watch yarn:build:esm:watch"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,16 +2,20 @@
   "name": "@roo-ui/components",
   "version": "0.62.4",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist",
-    "build:watch": "yarn run build --watch"
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel --root-mode upward src -d dist/cjs",
+    "build:esm": "ESM_BUILD=1 babel --root-mode upward src -d dist/esm",
+    "build:cjs:watch": "yarn run build:cjs --watch",
+    "build:esm:watch": "yarn run build:esm --watch",
+    "build:watch": "concurrently --kill-others yarn:build:cjs:watch yarn:build:esm:watch"
   },
   "devDependencies": {
     "@roo-ui/icons": "^0.62.2",

--- a/packages/icons/generateEcmaScriptModule.js
+++ b/packages/icons/generateEcmaScriptModule.js
@@ -54,8 +54,8 @@ const build = () => {
   const [validIcons, invalidIcons] = partitionByValidName(allIcons);
 
   console.log(`Skipping icons with invalid variable names: [${invalidIcons
-      .map(icon => JSON.stringify(icon.key))
-      .join(', ')}]`,);
+    .map(icon => JSON.stringify(icon.key))
+    .join(', ')}]`);
 
   const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'), {
     parser: 'babel',

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "node ./parseIcons.js && babel --root-mode upward dist/esm -d dist/cjs",
+    "build": "node ./generateEcmaScriptModule.js && babel --root-mode upward dist/esm -d dist/cjs",
     "build:watch": "onchange 'src/**/*.svg' -i -v -- yarn run build"
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -2,14 +2,15 @@
   "name": "@roo-ui/icons",
   "version": "0.62.2",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "node ./parseIcons.js",
+    "build": "node ./parseIcons.js && babel --root-mode upward dist/esm -d dist/cjs",
     "build:watch": "onchange 'src/**/*.svg' -i -v -- yarn run build"
   },
   "devDependencies": {

--- a/packages/icons/parseIcons.js
+++ b/packages/icons/parseIcons.js
@@ -10,7 +10,7 @@ const glob = require('glob');
 const prettier = require('prettier');
 
 const srcDir = 'src/**/*.svg';
-const filepath = 'dist/index.js';
+const filepath = 'dist/esm/index.js';
 
 const isValidIconName = (name) => {
   if (!isVarName(name)) {
@@ -41,7 +41,8 @@ const readIcons = dir =>
     path: svgToPath(file),
   }));
 
-const iconToExport = ({ key, category, path }) => `export const ${key} = ${JSON.stringify({ category, path })};\n`;
+const iconToExport = ({ key, category, path }) =>
+  `export const ${key} = ${JSON.stringify({ category, path })};\n`;
 
 const uniqueByKey = fp.uniqBy('key');
 
@@ -52,9 +53,13 @@ const build = () => {
   const allIcons = uniqueByKey(readIcons(srcDir));
   const [validIcons, invalidIcons] = partitionByValidName(allIcons);
 
-  console.log(`Skipping icons with invalid variable names: [${invalidIcons.map(icon => JSON.stringify(icon.key)).join(', ')}]`);
+  console.log(`Skipping icons with invalid variable names: [${invalidIcons
+      .map(icon => JSON.stringify(icon.key))
+      .join(', ')}]`,);
 
-  const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'), { parser: 'babel' });
+  const moduleContents = prettier.format(validIcons.map(iconToExport).join('\n'), {
+    parser: 'babel',
+  });
   fs.writeFileSync(filepath, moduleContents, 'utf8');
 };
 

--- a/packages/logos/package.json
+++ b/packages/logos/package.json
@@ -2,13 +2,18 @@
   "name": "@roo-ui/logos",
   "version": "0.58.10",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist --copy-files",
-    "build:watch": "yarn run build --watch"
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel --copy-files --root-mode upward src -d dist/cjs",
+    "build:esm": "ESM_BUILD=1 babel --copy-files --root-mode upward src -d dist/esm",
+    "build:cjs:watch": "yarn run build:cjs --watch",
+    "build:esm:watch": "yarn run build:esm --watch",
+    "build:watch": "concurrently --kill-others yarn:build:cjs:watch yarn:build:esm:watch"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -2,13 +2,18 @@
   "name": "@roo-ui/test-utils",
   "version": "0.58.10",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist",
-    "build:watch": "yarn run build --watch"
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel --root-mode upward src -d dist/cjs",
+    "build:esm": "ESM_BUILD=1 babel --root-mode upward src -d dist/esm",
+    "build:cjs:watch": "yarn run build:cjs --watch",
+    "build:esm:watch": "yarn run build:esm --watch",
+    "build:watch": "concurrently --kill-others yarn:build:cjs:watch yarn:build:esm:watch"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -2,13 +2,18 @@
   "name": "@roo-ui/themes",
   "version": "0.62.2",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "babel --root-mode upward src -d dist",
-    "build:watch": "yarn run build --watch"
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel --root-mode upward src -d dist/cjs",
+    "build:esm": "ESM_BUILD=1 babel --root-mode upward src -d dist/esm",
+    "build:cjs:watch": "yarn run build:cjs --watch",
+    "build:esm:watch": "yarn run build:esm --watch",
+    "build:watch": "concurrently --kill-others yarn:build:cjs:watch yarn:build:esm:watch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3601,6 +3601,21 @@ concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concurrently@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-4.1.1.tgz#42cf84d625163f3f5b2e2262568211ad76e1dbe8"
+  integrity sha512-48+FE5RJ0qc8azwKv4keVQWlni1hZeSjcWr8shBelOBtBHcKj1aJFM9lHRiSc1x7lq416pkvsqfBMhSRja+Lhw==
+  dependencies:
+    chalk "^2.4.1"
+    date-fns "^1.23.0"
+    lodash "^4.17.10"
+    read-pkg "^4.0.1"
+    rxjs "^6.3.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^4.5.0"
+    tree-kill "^1.1.0"
+    yargs "^12.0.1"
+
 config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -4144,7 +4159,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.29.0:
+date-fns@^1.23.0, date-fns@^1.29.0:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -5880,6 +5895,11 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -9890,6 +9910,15 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -10364,6 +10393,13 @@ rxjs@^6.1.0, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.3.3:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -10732,6 +10768,11 @@ space-separated-tokens@^1.0.0:
   dependencies:
     trim "0.0.1"
 
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
+
 spawn-promise@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/spawn-promise/-/spawn-promise-0.1.8.tgz#a5bea98814c48f52cbe02720e7fe2d6fc3b5119a"
@@ -11098,6 +11139,13 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
+supports-color@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
+  dependencies:
+    has-flag "^2.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -11410,7 +11458,7 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tree-kill@~1.2.0:
+tree-kill@^1.1.0, tree-kill@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
   integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
@@ -12142,7 +12190,7 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^12.0.2:
+yargs@^12.0.1, yargs@^12.0.2:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==


### PR DESCRIPTION
This PR creates both esm & cjs builds.

**Why?**
Jest configured by Create React App does not compile `node_modules`. And CRA disables the relevant jest configuration option.
