### PR TITLE
ensure color is overridable in ExternalLink

### DIFF
--- a/packages/components/src/ExternalLink/ExternalLink.js
+++ b/packages/components/src/ExternalLink/ExternalLink.js
@@ -1,16 +1,14 @@
 import styled from '@emotion/styled';
-import { themeGet } from 'styled-system';
 import { Link } from '..';
 
-const ExternalLink = styled(Link)`
-  color: ${themeGet('colors.greys.charcoal')};
-`;
+const ExternalLink = styled(Link)``;
 
 ExternalLink.defaultProps = {
   ...Link.defaultProps,
   rel: 'noopener noreferrer',
   target: '_blank',
   title: 'Link opens in new window',
+  color: 'greys.charcoal',
 };
 
 export default ExternalLink;


### PR DESCRIPTION
I would question whether we need the ExternalLink component at all, but we had a card up to make color over-writable, so here it is.