### PR TITLE
fix: refactor deprecated function

### DIFF
--- a/src/components/Hide/Hide.js
+++ b/src/components/Hide/Hide.js
@@ -2,11 +2,13 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { themeGet } from 'styled-system';
-import { getValueAndUnit } from 'polished';
+import { stripUnit } from 'polished';
 import memoize from 'lodash/memoize';
 
 // assuming root font-size is 16px
 const ONE_PX_IN_REM = 0.0625;
+
+const getValueAndUnit = value => stripUnit(value, true);
 
 const minusOnePx = memoize(value => {
   const [dimension, unit] = getValueAndUnit(value);


### PR DESCRIPTION
There was a deprecation warning coming out of the new version of polished. I wish they had of just kept the API the same, a Boolean second argument with no context to the function name always feels like a code smell. 

Oh well 🤷🏻‍♂️ this will silence the warnings.