### PR TITLE
fix: mark css files as having side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "!*.test.*",
     "!*.story.*"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "scripts": {
     "lint": "eslint .",
     "test": "jest",


### PR DESCRIPTION
With `side-effects: false` in `package.json`, `roo-ui/fonts/ciutadella.css` is omitted from production builds in consuming apps. 

This PR marks all css files as having side effects.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free