### PR TITLE
chore: add flexDirection, flexWrap and overflow support to Box

### DIFF
--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -14,6 +14,8 @@ import {
   borders,
   borderColor,
   flexBasis,
+  flexDirection,
+  flexWrap,
   flex,
   position,
   zIndex,
@@ -21,12 +23,13 @@ import {
   right,
   bottom,
   left,
+  overflow,
 } from 'styled-system';
 import styled from '@emotion/styled';
 import omitProps from '../omitProps';
 
 const Box = styled('div', omitProps())`
-  ${display} ${space} ${width} ${minWidth} ${maxWidth} ${height} ${minHeight} ${maxHeight} ${color} ${textAlign} ${boxShadow} ${borderRadius} ${borders} ${borderColor} ${flexBasis} ${flex} ${position} ${zIndex} ${top} ${right} ${bottom} ${left};
+  ${display} ${space} ${width} ${minWidth} ${maxWidth} ${height} ${minHeight} ${maxHeight} ${color} ${textAlign} ${boxShadow} ${borderRadius} ${borders} ${borderColor} ${flexBasis} ${flexDirection} ${flexWrap} ${flex} ${position} ${zIndex} ${top} ${right} ${bottom} ${left} ${overflow};
 `;
 
 Box.propTypes = {
@@ -45,6 +48,8 @@ Box.propTypes = {
   ...borders.propTypes,
   ...borderColor.propTypes,
   ...flexBasis.propTypes,
+  ...flexDirection.propTypes,
+  ...flexWrap.propTypes,
   ...flex.propTypes,
   ...position.propTypes,
   ...zIndex.propTypes,

--- a/src/components/Popover/__snapshots__/Popover.test.js.snap
+++ b/src/components/Popover/__snapshots__/Popover.test.js.snap
@@ -49,7 +49,7 @@ exports[`<Popover /> when popover is closed renders correctly 1`] = `
           >
             <Box>
               <div
-                className="css-1405epx-Box emotion-0"
+                className="css-ki38jf-Box emotion-0"
               >
                 <button
                   disabled={false}


### PR DESCRIPTION
Closes https://github.com/hooroo/roo-ui/issues/259

See https://github.com/hooroo/self-service/blob/master/src/components/Layout/Card/Card.js#L1 for justification.

I.e. in self-service our <Card/> extends roo-ui's <Card /> which extends <Box />, which support flex, and flexBasis, but not flexDirection or flexWrap ¯\_(ツ)_/¯ (or overflow - we're using that in one place in self-service.