### PR TITLE
fix: ensure refs are forwarded on form components

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -4,13 +4,15 @@ import { themeGet } from 'styled-system';
 import { rem } from 'polished';
 import { Icon } from '../';
 
-const Checkbox = props => (
+const Checkbox = React.forwardRef((props, ref) => (
   <CheckboxWrapper>
-    <CheckboxInput type="checkbox" {...props} />
+    <CheckboxInput type="checkbox" ref={ref} {...props} />
     <CheckboxBorder />
     <CheckboxIcon name="done" />
   </CheckboxWrapper>
-);
+));
+
+Checkbox.displayName = 'Checkbox';
 
 const CheckboxWrapper = styled.div`
   display: inline-block;

--- a/src/components/Checkbox/Checkbox.test.js
+++ b/src/components/Checkbox/Checkbox.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import theme from 'theme';
 import { mountWithTheme } from 'testUtils';
 import { axe } from 'jest-axe';
+import { renderIntoDocument, isDOMComponent } from 'react-dom/test-utils';
 
 import Checkbox from './';
 
@@ -25,6 +26,13 @@ describe('<Checkbox />', () => {
       theme,
     );
     expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('can handle a ref and pass it into a DOM component', () => {
+    const ref = React.createRef();
+
+    renderIntoDocument(<Checkbox ref={ref} />);
+    expect(isDOMComponent(ref.current)).toEqual(true);
   });
 
   describe('when checked', () => {

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -3,12 +3,14 @@ import styled from '@emotion/styled';
 import { themeGet } from 'styled-system';
 import { rem } from 'polished';
 
-const Radio = props => (
+const Radio = React.forwardRef((props, ref) => (
   <RadioWrapper>
-    <RadioInput type="radio" {...props} />
+    <RadioInput type="radio" ref={ref} {...props} />
     <RadioIcon />
   </RadioWrapper>
-);
+));
+
+Radio.displayName = 'Radio';
 
 const RadioWrapper = styled.div`
   display: inline-block;

--- a/src/components/Radio/Radio.test.js
+++ b/src/components/Radio/Radio.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import theme from 'theme';
 import { mountWithTheme } from 'testUtils';
 import { axe } from 'jest-axe';
+import { renderIntoDocument, isDOMComponent } from 'react-dom/test-utils';
 
 import Radio from './';
 
@@ -25,6 +26,13 @@ describe('<Radio />', () => {
       theme,
     );
     expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('can handle a ref and pass it into a DOM component', () => {
+    const ref = React.createRef();
+
+    renderIntoDocument(<Radio ref={ref} />);
+    expect(isDOMComponent(ref.current)).toEqual(true);
   });
 
   describe('when checked', () => {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -29,9 +29,9 @@ const IconWrapper = styled.div`
     `};
 `;
 
-const Base = props => (
+const Base = React.forwardRef((props, ref) => (
   <Wrapper>
-    <StyledSelect {...props} />
+    <StyledSelect ref={ref} {...props} />
 
     {!props.readOnly && (
       <IconWrapper disabled={props.disabled}>
@@ -39,7 +39,9 @@ const Base = props => (
       </IconWrapper>
     )}
   </Wrapper>
-);
+));
+
+Base.displayName = 'Base';
 
 Base.propTypes = Input.propTypes;
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import theme from 'theme';
 import { shallowWithTheme } from 'testUtils';
 import { axe } from 'jest-axe';
+import { renderIntoDocument, isDOMComponent } from 'react-dom/test-utils';
 
 import Select from './';
 
@@ -25,6 +26,13 @@ describe('<Select />', () => {
       theme,
     );
     expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('can handle a ref and pass it into a DOM component', () => {
+    const ref = React.createRef();
+
+    renderIntoDocument(<Select ref={ref} />);
+    expect(isDOMComponent(ref.current)).toEqual(true);
   });
 
   describe('disabled', () => {


### PR DESCRIPTION
## Description

Styled Components, et al, used to have an `innerRef` prop before React had proper ref forwarding support. At some point we switched to use `ref` but for got to forward it in our compound components. This PR will fix that for `Checkbox`, `Radio` and `Select`

💁‍
