### PR TITLE
fix(types): export popover control render props

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -445,12 +445,13 @@ declare module 'roo-ui/components' {
     zIndex?: number;
     modifiers?: PopperJS.Modifiers;
   }
+  export interface PopoverControlRenderProps {
+    isOpen: boolean;
+    openPopover: () => void;
+    closePopover: () => void;
+  }
   interface PopoverControlKnownProps extends BaseProps {
-    children: (args: {
-      isOpen: boolean;
-      openPopover: () => void;
-      closePopover: () => void;
-    }) => React.ReactNode;
+    children: (args: PopoverControlRenderProps) => React.ReactNode;
   }
   export interface PopoverControlProps
     extends PopoverControlKnownProps,


### PR DESCRIPTION
## Description

Export popover control render props as an interface so it can be used in consumer codebases.

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer (@angusfretwell, @talbet, @philipwindeyer)
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
