### PR TITLE
feat: add type definitions for omitProps

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -475,4 +475,12 @@ declare module 'roo-ui/components' {
     extends WrapperKnownProps,
       Omit<React.HTMLProps<HTMLDivElement>, keyof WrapperKnownProps> {}
   export const Wrapper: SC.StyledComponent<WrapperProps, WrapperProps, any>;
+
+  interface OmitPropsOptions {
+    omitStyledSystemProps?: boolean;
+  }
+  export const omitProps: (
+    customPropsList?: string[],
+    options?: OmitPropsOptions,
+  ) => SC.StyledOptions;
 }


### PR DESCRIPTION
## Description

Add type definitions for `omitProps` in `roo-ui/components`

**PR check-list**

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer (@angusfretwell, @talbet, @philipwindeyer)
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)