### PR TITLE
fix(types): accept string or number for rating in StarRating

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -130,7 +130,7 @@ declare module 'roo-ui/components' {
   >;
 
   export interface StarRatingProps extends SS.SizeProps {
-    rating: number;
+    rating: number | string;
     ratingType: 'AAA' | 'SELF_RATED';
   }
   export const StarRating: React.FunctionComponent<


### PR DESCRIPTION
## Description

Update `rating` on `StartRatingProps` to be `string | number` 