### PR TITLE
restrict ref to React.Ref<any> to be inline with emotion

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -12,6 +12,7 @@ declare module 'roo-ui/components' {
 
   export interface BaseProps extends React.Props<any> {
     as?: React.ReactType;
+    ref?: React.Ref<any>;
   }
 
   interface ColumnsProps {
@@ -125,25 +126,28 @@ declare module 'roo-ui/components' {
     firstDayOfWeek?: number;
     minDate?: Date;
   }
-  export const DatePicker: React.FunctionComponent<
-    Omit<DatePickerProps, 'children'>
-  >;
+  export const DatePicker: React.FunctionComponent<Omit<
+    DatePickerProps,
+    'children'
+  >>;
 
   export interface StarRatingProps extends SS.SizeProps {
     rating: number | string;
     ratingType: 'AAA' | 'SELF_RATED';
   }
-  export const StarRating: React.FunctionComponent<
-    Omit<StarRatingProps, 'children'>
-  >;
+  export const StarRating: React.FunctionComponent<Omit<
+    StarRatingProps,
+    'children'
+  >>;
 
   export interface LoadingIndicatorProps extends SS.SizeProps {
     color: SS.ResponsiveValue<CSS.ColorProperty>;
     delay?: number;
   }
-  export const LoadingIndicator: React.FunctionComponent<
-    Omit<LoadingIndicatorProps, 'children'>
-  >;
+  export const LoadingIndicator: React.FunctionComponent<Omit<
+    LoadingIndicatorProps,
+    'children'
+  >>;
 
   interface FlexKnownProps
     extends BoxProps,


### PR DESCRIPTION
## Description
Restricting `ref` type on interface `BaseProps` to be `React.Ref<any>` inline with emotion types

💁‍

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
