### PR TITLE
fix: do not display highlight state if outline button is disabled

### DIFF
--- a/src/components/OutlineButton/OutlineButton.js
+++ b/src/components/OutlineButton/OutlineButton.js
@@ -21,6 +21,10 @@ const OutlineButton = styled(Button)`
     border-color: ${getBackground};
   }
 
+  &:hover:disabled {
+    background-color: transparent;
+  }
+
   &:disabled {
     color: ${themeGet('colors.greys.dusty')};
     border-color: ${themeGet('colors.greys.dusty')};

--- a/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -60,6 +60,10 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
   border-color: #E40000;
 }
 
+.emotion-0:hover:disabled {
+  background-color: transparent;
+}
+
 .emotion-0:disabled {
   color: #999999;
   border-color: #999999;
@@ -138,6 +142,10 @@ exports[`<OutlineButton /> renders correctly 1`] = `
   border-color: #323232;
 }
 
+.emotion-0:hover:disabled {
+  background-color: transparent;
+}
+
 .emotion-0:disabled {
   color: #999999;
   border-color: #999999;
@@ -202,6 +210,10 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 .emotion-0:disabled {
   opacity: 0.7;
   cursor: not-allowed;
+}
+
+.emotion-0:hover:disabled {
+  background-color: transparent;
 }
 
 .emotion-0:disabled {


### PR DESCRIPTION
## Description

`<OutlineButton />` was rendering a hover state even if it was disabled. It was an oversight from inheriting the styling of `<Button />`.

💁‍

## Looks like this

![Screen Shot 2020-02-07 at 10 01 57 am](https://user-images.githubusercontent.com/1169014/73987584-fef9e980-4994-11ea-9821-c4e8ca363d06.png)


🤨

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [ ] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
