### PR TITLE
refactor(alert): pass box props through

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -8,7 +8,7 @@ import { Container, NakedButton, Text, Flex, Box, Icon } from '../';
 const alertFactory = defaultVariant => {
   const BaseAlert = withTheme(
     ({ children, onClose, contained, theme, variant, ...props }) => {
-      const { icon, bg } = {
+      const { icon, ...boxProps } = {
         ...themeGet(`alertStyles.${variant}`)({ theme }),
         ...props,
       };
@@ -16,7 +16,7 @@ const alertFactory = defaultVariant => {
       const Wrapper = contained ? Container : Box;
 
       return (
-        <Box {...props} bg={bg}>
+        <Box {...props} {...boxProps}>
           <Wrapper px={contained ? undefined : 4}>
             <Flex py={4}>
               {icon && (


### PR DESCRIPTION
## Description

Pass box props through in Alert component
💁‍

## Related issues

💪

## Looks like this

🤨

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
