### PR TITLE
fix: allow icons to use responsive sizes

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -38,6 +38,8 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -187,6 +189,8 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -336,6 +340,8 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -485,6 +491,8 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -634,6 +642,8 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -783,6 +793,8 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -47,6 +47,8 @@ input:checked ~ .emotion-7 {
 }
 
 .emotion-5 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -172,6 +174,8 @@ input:checked ~ .emotion-7 {
 }
 
 .emotion-5 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -301,6 +305,8 @@ input:checked ~ .emotion-7 {
 }
 
 .emotion-5 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -58,6 +58,8 @@ exports[`<CalendarNav /> renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
-import { space, color } from 'styled-system';
+import { space, width, height, color } from 'styled-system';
 import PropTypes from 'prop-types';
 
 const IS_TEST = process.env.NODE_ENV === 'test';
@@ -24,7 +24,10 @@ const getSvgPathFromTheme = (theme, name) => {
   return icon.path;
 };
 
-const StyledSvg = styled.svg``;
+const StyledSvg = styled.svg`
+  ${width}
+  ${height}
+`;
 
 const Base = withTheme(({ name, title, size, theme, ...props }) => (
   <StyledSvg
@@ -54,7 +57,8 @@ Base.defaultProps = {
 const Icon = styled(Base)`
   vertical-align: middle;
   flex: none;
-  ${space} ${color};
+  ${space}
+  ${color}
 `;
 
 Icon.propTypes = {

--- a/src/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.js.snap
@@ -9,6 +9,8 @@ exports[`<Icon /> when passed icon name in theme renders correctly 1`] = `
 }
 
 .emotion-1 {
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -173,6 +173,8 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
 }
 
 .emotion-6 {
+  width: 22px;
+  height: 22px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;
@@ -451,6 +453,8 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
 }
 
 .emotion-6 {
+  width: 22px;
+  height: 22px;
   vertical-align: middle;
   -webkit-flex: none;
   -ms-flex: none;


### PR DESCRIPTION
This PR allows icons to use responsive sizes by delegating width and height back to Styled System so that the following is possible:
```js
<Icon name="close" size={[16,24]} />
```