### PR TITLE
fix: better a11y for svg icons

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -118,6 +118,9 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                warning
+                              </title>
                               <path
                                 d={null}
                               />
@@ -269,6 +272,9 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                info
+                              </title>
                               <path
                                 d={null}
                               />
@@ -420,6 +426,9 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                checkCircle
+                              </title>
                               <path
                                 d={null}
                               />
@@ -571,6 +580,9 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                warning
+                              </title>
                               <path
                                 d={null}
                               />
@@ -722,6 +734,9 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                info
+                              </title>
                               <path
                                 d={null}
                               />
@@ -873,6 +888,9 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
+                              <title>
+                                checkCircle
+                              </title>
                               <path
                                 d={null}
                               />

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -114,6 +114,9 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
+                <title>
+                  done
+                </title>
                 <path
                   d={null}
                 />
@@ -245,6 +248,9 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
+                <title>
+                  done
+                </title>
                 <path
                   d={null}
                 />
@@ -376,6 +382,9 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
+                <title>
+                  done
+                </title>
                 <path
                   d={null}
                 />

--- a/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -130,6 +130,9 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                     viewBox="0 0 24 24"
                     width={24}
                   >
+                    <title>
+                      chevronLeft
+                    </title>
                     <path
                       d={null}
                     />
@@ -188,6 +191,9 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                     viewBox="0 0 24 24"
                     width={24}
                   >
+                    <title>
+                      chevronRight
+                    </title>
                     <path
                       d={null}
                     />

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -38,13 +38,18 @@ const Base = withTheme(({ name, title, size, theme, ...props }) => (
     title={title || name}
     fill="currentcolor"
   >
+    <title>{title || name}</title>
     <path d={getSvgPathFromTheme(theme, name)} />
   </StyledSvg>
 ));
 
 Base.propTypes = {
   name: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  size: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.array,
+  ]),
   title: PropTypes.string,
 };
 

--- a/src/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.js.snap
@@ -50,6 +50,9 @@ exports[`<Icon /> when passed icon name in theme renders correctly 1`] = `
           viewBox="0 0 24 24"
           width={24}
         >
+          <title>
+            hotel
+          </title>
           <path
             d="M7 13c1.66 0 3-1.34 3-3S8.66 7 7 7s-3 1.34-3 3 1.34 3 3 3zm12-6h-8v7H3V5H1v15h2v-3h18v3h2v-9c0-2.21-1.79-4-4-4z"
           />

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -263,6 +263,9 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                       viewBox="0 0 24 24"
                       width={22}
                     >
+                      <title>
+                        visibility
+                      </title>
                       <path
                         d={null}
                       />
@@ -543,6 +546,9 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                       viewBox="0 0 24 24"
                       width={22}
                     >
+                      <title>
+                        visibilityOff
+                      </title>
                       <path
                         d={null}
                       />


### PR DESCRIPTION
By adding `<title>` to the SVG tags we can make the icons more accessible, this is particularly important when creating buttons with icons, but no text. 