### PR TITLE
fix: changes to titles in icons for better a11y

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -118,9 +118,6 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                warning
-                              </title>
                               <path
                                 d={null}
                               />
@@ -272,9 +269,6 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                info
-                              </title>
                               <path
                                 d={null}
                               />
@@ -426,9 +420,6 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                checkCircle
-                              </title>
                               <path
                                 d={null}
                               />
@@ -580,9 +571,6 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                warning
-                              </title>
                               <path
                                 d={null}
                               />
@@ -734,9 +722,6 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                info
-                              </title>
                               <path
                                 d={null}
                               />
@@ -888,9 +873,6 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                               viewBox="0 0 24 24"
                               width={24}
                             >
-                              <title>
-                                checkCircle
-                              </title>
                               <path
                                 d={null}
                               />

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -114,9 +114,6 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
-                <title>
-                  done
-                </title>
                 <path
                   d={null}
                 />
@@ -248,9 +245,6 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
-                <title>
-                  done
-                </title>
                 <path
                   d={null}
                 />
@@ -382,9 +376,6 @@ input:checked ~ .emotion-5 {
                 viewBox="0 0 24 24"
                 width={24}
               >
-                <title>
-                  done
-                </title>
                 <path
                   d={null}
                 />

--- a/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -130,9 +130,6 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                     viewBox="0 0 24 24"
                     width={24}
                   >
-                    <title>
-                      chevronLeft
-                    </title>
                     <path
                       d={null}
                     />
@@ -191,9 +188,6 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                     viewBox="0 0 24 24"
                     width={24}
                   >
-                    <title>
-                      chevronRight
-                    </title>
                     <path
                       d={null}
                     />

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -38,7 +38,7 @@ const Base = withTheme(({ name, title, size, theme, ...props }) => (
     title={title || name}
     fill="currentcolor"
   >
-    <title>{title || name}</title>
+    {title && <title>{title}</title>}
     <path d={getSvgPathFromTheme(theme, name)} />
   </StyledSvg>
 ));

--- a/src/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.js.snap
@@ -50,9 +50,6 @@ exports[`<Icon /> when passed icon name in theme renders correctly 1`] = `
           viewBox="0 0 24 24"
           width={24}
         >
-          <title>
-            hotel
-          </title>
           <path
             d="M7 13c1.66 0 3-1.34 3-3S8.66 7 7 7s-3 1.34-3 3 1.34 3 3 3zm12-6h-8v7H3V5H1v15h2v-3h18v3h2v-9c0-2.21-1.79-4-4-4z"
           />

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -263,9 +263,6 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                       viewBox="0 0 24 24"
                       width={22}
                     >
-                      <title>
-                        visibility
-                      </title>
                       <path
                         d={null}
                       />
@@ -546,9 +543,6 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                       viewBox="0 0 24 24"
                       width={22}
                     >
-                      <title>
-                        visibilityOff
-                      </title>
                       <path
                         d={null}
                       />


### PR DESCRIPTION
The last PR for a11y was a little off. I think we should be adding a title element if it is explicitly passed to the component, but we should not be using the `name` of the icon as a default.

Icons that are purely decoration should not have a title element, and the default behavior was adding titles to decoration icons.