### PR TITLE
fix: typo in Label was breaking css tests

### DIFF
--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -7,7 +7,7 @@ import omitProps from '../omitProps';
 
 const Label = styled('label', omitProps(['hidden']))`
   ${props => props.hidden && hideVisually()}
-  ${display}:
+  ${display}
   ${width}
   ${textStyle}
   ${space}


### PR DESCRIPTION
fixing a typo that created invalid css