### PR TITLE
fix: prevent warnings on responsive icons

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -111,12 +111,9 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="ui.error"
                               fill="currentcolor"
-                              height={24}
                               title="warning"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}
@@ -262,12 +259,9 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="greys.charcoal"
                               fill="currentcolor"
-                              height={24}
                               title="info"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}
@@ -413,12 +407,9 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="ui.success"
                               fill="currentcolor"
-                              height={24}
                               title="checkCircle"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}
@@ -564,12 +555,9 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="ui.error"
                               fill="currentcolor"
-                              height={24}
                               title="warning"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}
@@ -715,12 +703,9 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="greys.charcoal"
                               fill="currentcolor"
-                              height={24}
                               title="info"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}
@@ -866,12 +851,9 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
                           >
                             <svg
                               className="emotion-0 emotion-1 emotion-2"
-                              color="ui.success"
                               fill="currentcolor"
-                              height={24}
                               title="checkCircle"
                               viewBox="0 0 24 24"
-                              width={24}
                             >
                               <path
                                 d={null}

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -109,10 +109,8 @@ input:checked ~ .emotion-5 {
               <svg
                 className="emotion-4 emotion-5 emotion-6"
                 fill="currentcolor"
-                height={24}
                 title="done"
                 viewBox="0 0 24 24"
-                width={24}
               >
                 <path
                   d={null}
@@ -240,10 +238,8 @@ input:checked ~ .emotion-5 {
               <svg
                 className="emotion-4 emotion-5 emotion-6"
                 fill="currentcolor"
-                height={24}
                 title="done"
                 viewBox="0 0 24 24"
-                width={24}
               >
                 <path
                   d={null}
@@ -371,10 +367,8 @@ input:checked ~ .emotion-5 {
               <svg
                 className="emotion-4 emotion-5 emotion-6"
                 fill="currentcolor"
-                height={24}
                 title="done"
                 viewBox="0 0 24 24"
-                width={24}
               >
                 <path
                   d={null}

--- a/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -125,10 +125,8 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                   <svg
                     className="emotion-0 emotion-1 emotion-2"
                     fill="currentcolor"
-                    height={24}
                     title="chevronLeft"
                     viewBox="0 0 24 24"
-                    width={24}
                   >
                     <path
                       d={null}
@@ -183,10 +181,8 @@ exports[`<CalendarNav /> renders correctly 1`] = `
                   <svg
                     className="emotion-0 emotion-1 emotion-2"
                     fill="currentcolor"
-                    height={24}
                     title="chevronRight"
                     viewBox="0 0 24 24"
-                    width={24}
                   >
                     <path
                       d={null}

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
 import { space, width, height, color } from 'styled-system';
 import PropTypes from 'prop-types';
+import omitProps from '../omitProps';
 
 const IS_TEST = process.env.NODE_ENV === 'test';
 
@@ -24,7 +25,7 @@ const getSvgPathFromTheme = (theme, name) => {
   return icon.path;
 };
 
-const StyledSvg = styled.svg`
+const StyledSvg = styled('svg', omitProps(['width', 'height']))`
   ${width}
   ${height}
 `;

--- a/src/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.js.snap
@@ -45,10 +45,8 @@ exports[`<Icon /> when passed icon name in theme renders correctly 1`] = `
         <svg
           className="emotion-0 emotion-1 emotion-2"
           fill="currentcolor"
-          height={24}
           title="hotel"
           viewBox="0 0 24 24"
-          width={24}
         >
           <path
             d="M7 13c1.66 0 3-1.34 3-3S8.66 7 7 7s-3 1.34-3 3 1.34 3 3 3zm12-6h-8v7H3V5H1v15h2v-3h18v3h2v-9c0-2.21-1.79-4-4-4z"

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.test.js.snap
@@ -258,10 +258,8 @@ exports[`<PasswordInput /> when visibility is not toggled renders correctly 1`] 
                     <svg
                       className="emotion-5 emotion-6 emotion-7"
                       fill="currentcolor"
-                      height={22}
                       title="visibility"
                       viewBox="0 0 24 24"
-                      width={22}
                     >
                       <path
                         d={null}
@@ -538,10 +536,8 @@ exports[`<PasswordInput /> when visibility is toggled renders correctly 1`] = `
                     <svg
                       className="emotion-5 emotion-6 emotion-7"
                       fill="currentcolor"
-                      height={22}
                       title="visibilityOff"
                       viewBox="0 0 24 24"
-                      width={22}
                     >
                       <path
                         d={null}


### PR DESCRIPTION
Using responsive icons causes a warning in browsers, because the size array is converted to a string and added to the SVG as an attribute. We don't need the attributes since the size is already controlled by CSS