### PR TITLE
Fix/replace strip unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "dayzed": "^3.0.0",
     "emotion-theming": "^10.0.17",
     "lodash": "^4.17.15",
-    "polished": "^3.4.1",
+    "polished": "^3.6.5",
     "react-modal": "^3.10.1",
     "react-onclickoutside": "^6.9.0",
     "react-popper": "^1.3.4",

--- a/src/components/Hide/Hide.js
+++ b/src/components/Hide/Hide.js
@@ -2,13 +2,11 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { themeGet } from 'styled-system';
-import { stripUnit } from 'polished';
+import { getValueAndUnit } from 'polished';
 import memoize from 'lodash/memoize';
 
 // assuming root font-size is 16px
 const ONE_PX_IN_REM = 0.0625;
-
-const getValueAndUnit = value => stripUnit(value, true);
 
 const minusOnePx = memoize(value => {
   const [dimension, unit] = getValueAndUnit(value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,6 +914,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.9.2":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -10496,12 +10503,19 @@ pnp-webpack-plugin@1.4.3:
   dependencies:
     ts-pnp "^1.1.2"
 
-polished@^3.3.1, polished@^3.4.1:
+polished@^3.3.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.1.tgz#1eb5597ec1792206365635811d465751f5cbf71c"
   integrity sha512-GflTnlP5rrpDoigjczEkS6Ye7NDA4sFvAnlr5hSDrEvjiVj97Xzev3hZlLi3UB27fpxyTS9rWU64VzVLWkG+mg==
   dependencies:
     "@babel/runtime" "^7.4.5"
+
+polished@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.5.tgz#dbefdde64c675935ec55119fe2a2ab627ca82e9c"
+  integrity sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.15.0"
@@ -11534,6 +11548,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.6.tgz#d236043c46ffab2968c1ef651803d8acdea8ed65"
+  integrity sha512-GmwlGiazQEbOwQWDdbbaP10i15pGtScYWLbMZuu+RKRz0cZ+g8IUONazBnaZqe7j1670IV1HgE4/8iy7CQPf4Q==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
## Description

Bumped version of `polished` and replaced a custom method `getValueAndUnit` with a `polished` one. Functionality remains the same. Reason for change: we've been seeing warning messages:
`stripUnit's unitReturn functionality has been marked for deprecation in polished 4.0. It's functionality has been been moved to getValueAndUnit. `

💁‍


---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
