### PR TITLE
add missing types to box

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -91,7 +91,9 @@ declare module 'roo-ui/components' {
       SS.LeftProps,
       SS.OverflowProps,
       SS.WidthProps,
-      SS.HeightProps {}
+      SS.HeightProps,
+      SS.FontSizeProps,
+      SS.FontWeightProps {}
   export interface BoxProps
     extends BoxKnownProps,
       Omit<React.HTMLProps<HTMLDivElement>, keyof BoxKnownProps> {}


### PR DESCRIPTION
These props were added to Box previously but type defs weren't updated.

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
