### PR TITLE
fix: add missing display prop types to Container prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@storybook/addons": "^5.1.11",
     "@storybook/react": "^5.1.11",
     "@types/react": "^16.9.2",
-    "@types/styled-system": "^5.1.1",
+    "@types/styled-system": "^4.1.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-emotion": "^10.0.17",

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -125,31 +125,28 @@ declare module 'roo-ui/components' {
     monthNames?: string[];
     weekdayNames?: string[];
     monthsToDisplay?: number;
-    firstDayOfWeek?: number;
+    firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
     minDate?: Date;
   }
-  export const DatePicker: React.FunctionComponent<Omit<
-    DatePickerProps,
-    'children'
-  >>;
+  export const DatePicker: React.FunctionComponent<
+    Omit<DatePickerProps, 'children'>
+  >;
 
   export interface StarRatingProps extends SS.SizeProps {
     rating: number | string;
     ratingType: 'AAA' | 'SELF_RATED';
   }
-  export const StarRating: React.FunctionComponent<Omit<
-    StarRatingProps,
-    'children'
-  >>;
+  export const StarRating: React.FunctionComponent<
+    Omit<StarRatingProps, 'children'>
+  >;
 
   export interface LoadingIndicatorProps extends SS.SizeProps {
     color: SS.ResponsiveValue<CSS.ColorProperty>;
     delay?: number;
   }
-  export const LoadingIndicator: React.FunctionComponent<Omit<
-    LoadingIndicatorProps,
-    'children'
-  >>;
+  export const LoadingIndicator: React.FunctionComponent<
+    Omit<LoadingIndicatorProps, 'children'>
+  >;
 
   interface FlexKnownProps
     extends BoxProps,
@@ -167,6 +164,7 @@ declare module 'roo-ui/components' {
   interface ContainerKnownProps
     extends BaseProps,
       GutterProps,
+      SS.DisplayProps,
       SS.MaxWidthProps,
       SS.SpaceProps {}
   export interface ContainerProps

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,10 +2134,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-system@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.1.tgz#22eff9e4b2f89cd2222c15053f8c11be5ec9c357"
-  integrity sha512-RAF9Erif51vbD1ZbIiGN4ZrgxpSr44iMXrPjQK5+tI7PWLDugKepTWj7T/LqG5VfaYYIrEmOCzIpulhv+/D/XQ==
+"@types/styled-system@^4.1.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-4.2.2.tgz#d8ec981978dc303849030c2428c92e2d472507ff"
+  integrity sha512-eULPjWVEaXElIFKBwDVWRvGkHC0Fj63XVRna8RHoaRivNhCI/QkEJpMgyb0uA4WpsHpO5SDXH+DyQwEUkyW3rA==
   dependencies:
     csstype "^2.6.4"
 


### PR DESCRIPTION
## Description

Add `display` to `ContainerPropTypes`.

Also downgraded `@types/styled system` types to `^4.1.0` to match the used `styled-system` version
