### PR TITLE
feat: add ButtonGroup component to roo-ui

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Flex } from '../';
+import ButtonGroupOption from './ButtonGroupOption';
+
+const ButtonGroup = ({
+  name,
+  value,
+  options,
+  disabled,
+  size,
+  onChange,
+  ...rest
+}) => {
+  const [checked, setChecked] = useState(value);
+
+  const handleChange = value => {
+    setChecked(value);
+    onChange(value);
+  };
+
+  return (
+    <Flex role="radiogroup" aria-label={name} {...rest}>
+      {options.map((option, index) => (
+        <ButtonGroupOption
+          key={index}
+          id={`buttonGroup_${name}_${index}`}
+          name={name}
+          label={option.label}
+          value={option.value}
+          checked={option.value === checked}
+          disabled={disabled}
+          size={size}
+          totalOptions={options.length}
+          onChange={handleChange}
+        />
+      ))}
+    </Flex>
+  );
+};
+
+ButtonGroup.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node.isRequired,
+      value: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  size: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.array,
+  ]),
+};
+
+ButtonGroup.defaultProps = {
+  disabled: false,
+  size: 'base',
+};
+
+export default ButtonGroup;

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '../';
+import styled from '@emotion/styled';
+import Flex from '../Flex';
 import ButtonGroupOption from './ButtonGroupOption';
+
+// Setting a transform here creates a stacking context, so the we can use z-index
+// in ButtonGroupOption without worrying about z-index conflicts with other components
+const ButtonGroupWrapper = styled(Flex)`
+  transform: scale(1);
+`;
 
 const ButtonGroup = ({
   name,
@@ -20,7 +27,7 @@ const ButtonGroup = ({
   };
 
   return (
-    <Flex role="radiogroup" aria-label={name} {...rest}>
+    <ButtonGroupWrapper role="radiogroup" aria-label={name} {...rest}>
       {options.map((option, index) => (
         <ButtonGroupOption
           key={index}
@@ -35,7 +42,7 @@ const ButtonGroup = ({
           onChange={handleChange}
         />
       ))}
-    </Flex>
+    </ButtonGroupWrapper>
   );
 };
 

--- a/src/components/ButtonGroup/ButtonGroup.story.js
+++ b/src/components/ButtonGroup/ButtonGroup.story.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withDocs } from 'storybook-readme';
+import noop from 'lodash/noop';
+
+import ButtonGroup from './';
+import README from './README.md';
+
+const DEFAULT_OPTIONS = [
+  { label: 'Upcoming', value: 'upcoming' },
+  { label: 'Past', value: 'past' },
+  { label: 'Cancelled', value: 'cancelled' },
+];
+
+storiesOf('Components|ButtonGroup', module)
+  .addDecorator(withDocs(README))
+  .add('default', () => (
+    <ButtonGroup
+      name="bookings-by-type"
+      value="upcoming"
+      options={DEFAULT_OPTIONS}
+      onChange={noop}
+    />
+  ))
+  .add('disabled', () => (
+    <ButtonGroup
+      name="bookings-by-type"
+      value="cancelled"
+      disabled={true}
+      options={DEFAULT_OPTIONS}
+      onChange={noop}
+    />
+  ))
+  .add('two-options', () => (
+    <ButtonGroup
+      name="two-options"
+      value="cash"
+      options={[
+        { label: 'Use cash', value: 'cash' },
+        { label: 'Use points', value: 'points' },
+      ]}
+      onChange={noop}
+    />
+  ));

--- a/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/src/components/ButtonGroup/ButtonGroup.test.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import theme from 'theme';
+import { shallowWithTheme } from 'testUtils';
+import { axe } from 'jest-axe';
+import ButtonGroup from './';
+import ButtonGroupOption from './ButtonGroupOption';
+
+describe('<ButtonGroup />', () => {
+  let props;
+  let optionNodes;
+  let wrapper;
+
+  const render = () => shallowWithTheme(<ButtonGroup {...props} />, theme);
+
+  beforeEach(() => {
+    props = {
+      name: 'testButtonGroup',
+      value: 'one',
+      disabled: false,
+      options: [
+        {
+          label: 'One',
+          value: 'one',
+        },
+        {
+          label: 'Two',
+          value: 'two',
+        },
+      ],
+      onChange: jest.fn(),
+      size: 'sm',
+    };
+
+    wrapper = render();
+    optionNodes = wrapper.find(ButtonGroupOption);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('has no accessibility errors', async () => {
+    expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('passes label prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('label'));
+    expect(values).toEqual(['One', 'Two']);
+  });
+
+  it('passes name prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('name'));
+    expect(values).toEqual([props.name, props.name]);
+  });
+
+  it('passes value prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('value'));
+    expect(values).toEqual(['one', 'two']);
+  });
+
+  it('passes checked prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('checked'));
+    expect(values).toEqual([true, false]);
+  });
+
+  it('passes disabled prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('disabled'));
+    expect(values).toEqual([false, false]);
+  });
+
+  it('passes size prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('size'));
+    expect(values).toEqual(['sm', 'sm']);
+  });
+
+  it('passes id prop to each ButtonGroupOption', () => {
+    const values = optionNodes.map(node => node.prop('id'));
+    expect(values).toEqual([
+      'buttonGroup_testButtonGroup_0',
+      'buttonGroup_testButtonGroup_1',
+    ]);
+  });
+
+  describe('onChange', () => {
+    let values;
+
+    beforeEach(() => {
+      values = optionNodes.map(node => node.prop('onChange'));
+      values.forEach(fn => fn());
+    });
+
+    it('passes a handleChange prop to each ButtonGroupOption', () => {
+      expect(values).toEqual([expect.any(Function), expect.any(Function)]);
+    });
+
+    it('invokes the onChange fn passed to ButtonGroup when called', () => {
+      expect(props.onChange).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/ButtonGroup/ButtonGroupOption/ButtonGroupOption.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/ButtonGroupOption.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { HiddenInput, ButtonLabel } from './primitives';
+
+const ButtonGroupOption = ({
+  id,
+  name,
+  label,
+  value,
+  checked,
+  disabled,
+  size,
+  totalOptions,
+  onChange,
+}) => {
+  const [clicked, setClicked] = useState(false);
+
+  const handleLabelClick = () => {
+    setClicked(true);
+  };
+
+  const handleInputFocus = event => {
+    if (clicked) {
+      setClicked(false);
+      event.target.blur();
+    }
+  };
+
+  const handleChange = event => {
+    if (!disabled) {
+      onChange(event.target.value);
+    }
+  };
+
+  return (
+    <>
+      <HiddenInput
+        type="radio"
+        id={id}
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={handleChange}
+        onFocus={handleInputFocus}
+        disabled={disabled}
+      />
+      <ButtonLabel
+        htmlFor={id}
+        onClick={handleLabelClick}
+        size={size}
+        totalOptions={totalOptions}
+      >
+        {label}
+      </ButtonLabel>
+    </>
+  );
+};
+
+ButtonGroupOption.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  value: PropTypes.string.isRequired,
+  checked: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  size: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.array,
+  ]),
+  totalOptions: PropTypes.number.isRequired,
+};
+
+ButtonGroupOption.defaultProps = {
+  checked: false,
+  disabled: false,
+  size: 'base',
+};
+
+export default ButtonGroupOption;

--- a/src/components/ButtonGroup/ButtonGroupOption/ButtonGroupOption.test.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/ButtonGroupOption.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import theme from 'theme';
+import { mountWithTheme } from 'testUtils';
+import { axe } from 'jest-axe';
+import ButtonGroupOption from './ButtonGroupOption';
+import { ButtonLabel, HiddenInput } from './primitives';
+
+describe('<ButtonGroupOption />', () => {
+  let props;
+  let wrapper;
+  let input;
+  let inputDOMNode;
+  let label;
+  let labelDOMNode;
+  let blurSpy;
+
+  beforeEach(() => {
+    props = {
+      id: 'radio_one',
+      name: 'radio_one',
+      label: 'Click Me',
+      value: 'radio_one_value',
+      checked: false,
+      disabled: false,
+      onChange: jest.fn(),
+      size: 'sm',
+      totalOptions: 3,
+    };
+
+    wrapper = mountWithTheme(<ButtonGroupOption {...props} />, theme);
+    label = wrapper.find(ButtonLabel);
+    labelDOMNode = label.getDOMNode();
+    input = wrapper.find(HiddenInput);
+    inputDOMNode = input.getDOMNode();
+    blurSpy = jest.spyOn(inputDOMNode, 'blur');
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('has no accessibility errors', async () => {
+    expect(await axe(wrapper.html())).toHaveNoViolations();
+  });
+
+  it('renders HiddenInput with expected props', () => {
+    expect(input.props()).toEqual({
+      type: 'radio',
+      id: props.id,
+      name: props.name,
+      value: props.value,
+      checked: props.checked,
+      disabled: props.disabled,
+      onChange: expect.any(Function),
+      onFocus: expect.any(Function),
+    });
+  });
+
+  it('renders ButtonLabel with expected props', () => {
+    expect(label.props()).toEqual({
+      htmlFor: props.id,
+      onClick: expect.any(Function),
+      children: props.label,
+      size: props.size,
+      totalOptions: props.totalOptions,
+    });
+  });
+
+  describe('when input is clicked', () => {
+    beforeEach(() => {
+      label.simulate('click', { target: labelDOMNode });
+      input.simulate('focus', { target: inputDOMNode });
+      input.simulate('change', { target: inputDOMNode });
+    });
+
+    it('calls props.onChange with value', () => {
+      expect(props.onChange).toHaveBeenCalledWith(props.value);
+    });
+
+    it('blurs the input', () => {
+      expect(blurSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('when input is changed using keyboard', () => {
+    beforeEach(() => {
+      input.simulate('focus', { target: inputDOMNode });
+      input.simulate('change', { target: inputDOMNode });
+    });
+
+    it('calls props.onChange with value', () => {
+      expect(props.onChange).toHaveBeenCalledWith(props.value);
+    });
+
+    it('does not blur the input', () => {
+      expect(blurSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
+++ b/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
@@ -30,22 +30,18 @@ exports[`<ButtonGroupOption /> renders correctly 1`] = `
   cursor: pointer;
   -webkit-transition: font-size 200ms ease-in-out;
   transition: font-size 200ms ease-in-out;
-  border-left: 1px solid;
-  border-right: 1px solid;
-  border-top: 2px solid;
-  border-bottom: 2px solid;
+  border: 2px solid;
+  margin-left: -2px;
+  z-index: 1;
 }
 
 .emotion-2:first-of-type {
-  border-left: 2px solid;
-}
-
-.emotion-2:last-of-type {
-  border-right: 2px solid;
+  margin-left: 0;
 }
 
 .emotion-1:checked + .emotion-2 {
   cursor: unset;
+  z-index: 2;
 }
 
 .emotion-1:disabled + .emotion-2 {

--- a/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
+++ b/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonGroupOption /> renders correctly 1`] = `
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-2 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 33.333333333333336%;
+  white-space: nowrap;
+  text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: null null;
+  cursor: pointer;
+  -webkit-transition: font-size 200ms ease-in-out;
+  transition: font-size 200ms ease-in-out;
+  border-left: 1px solid;
+  border-right: 1px solid;
+  border-top: 2px solid;
+  border-bottom: 2px solid;
+}
+
+.emotion-2:first-of-type {
+  border-left: 2px solid;
+}
+
+.emotion-2:last-of-type {
+  border-right: 2px solid;
+}
+
+.emotion-1:checked + .emotion-2 {
+  cursor: unset;
+}
+
+.emotion-1:disabled + .emotion-2 {
+  cursor: unset;
+}
+
+<ButtonGroupOption
+  checked={false}
+  disabled={false}
+  id="radio_one"
+  label="Click Me"
+  name="radio_one"
+  onChange={[MockFunction]}
+  size="sm"
+  totalOptions={3}
+  value="radio_one_value"
+>
+  <HiddenInput
+    checked={false}
+    disabled={false}
+    id="radio_one"
+    name="radio_one"
+    onChange={[Function]}
+    onFocus={[Function]}
+    type="radio"
+    value="radio_one_value"
+  >
+    <input
+      checked={false}
+      className="emotion-0 emotion-1"
+      disabled={false}
+      id="radio_one"
+      name="radio_one"
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="radio"
+      value="radio_one_value"
+    />
+  </HiddenInput>
+  <ButtonLabel
+    htmlFor="radio_one"
+    onClick={[Function]}
+    size="sm"
+    totalOptions={3}
+  >
+    <label
+      className="emotion-2 emotion-3"
+      htmlFor="radio_one"
+      onClick={[Function]}
+      size="sm"
+    >
+      Click Me
+    </label>
+  </ButtonLabel>
+</ButtonGroupOption>
+`;

--- a/src/components/ButtonGroup/ButtonGroupOption/index.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/index.js
@@ -1,0 +1,1 @@
+export { default } from './ButtonGroupOption';

--- a/src/components/ButtonGroup/ButtonGroupOption/primitives.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/primitives.js
@@ -38,20 +38,17 @@ export const ButtonLabel = styled.label`
   color: ${steel};
   font-weight: ${bold};
   transition: font-size 200ms ease-in-out;
-
-  border-left: 1px solid ${alto};
-  border-right: 1px solid ${alto};
-  border-top: 2px solid ${alto};
-  border-bottom: 2px solid ${alto};
+  border: 2px solid ${alto};
+  margin-left: -2px;
+  z-index: 1;
 
   &:first-of-type {
-    border-left: 2px solid ${alto};
+    margin-left: 0;
     border-top-left-radius: ${borderRadius};
     border-bottom-left-radius: ${borderRadius};
   }
 
   &:last-of-type {
-    border-right: 2px solid ${alto};
     border-top-right-radius: ${borderRadius};
     border-bottom-right-radius: ${borderRadius};
   }
@@ -61,6 +58,7 @@ export const ButtonLabel = styled.label`
     border-color: ${blue};
     background-color: ${white};
     cursor: unset;
+    z-index: 2;
   }
 
   ${HiddenInput}:focus + & {

--- a/src/components/ButtonGroup/ButtonGroupOption/primitives.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/primitives.js
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+import { themeGet } from 'styled-system';
+import { hideVisually } from 'polished';
+
+const white = themeGet('colors.white');
+const blue = themeGet('colors.blue');
+const dusty = themeGet('colors.greys.dusty');
+const steel = themeGet('colors.greys.steel');
+const charcoal = themeGet('colors.greys.charcoal');
+const alto = themeGet('colors.greys.alto');
+const porcelain = themeGet('colors.greys.porcelain');
+const borderRadius = themeGet('radii.default');
+const bold = themeGet('fontWeights.bold');
+
+const compactPadding = props =>
+  `${themeGet('space.2')(props)} ${themeGet('space.4')(props)}`;
+const basePadding = props =>
+  `${themeGet('space.3')(props)} ${themeGet('space.5')(props)}`;
+
+const getFontSize = ({ size = 'base' }) => themeGet(`fontSizes.${size}`);
+
+export const HiddenInput = styled.input`
+  ${hideVisually()};
+`;
+
+export const ButtonLabel = styled.label`
+  position: relative;
+  flex: 1 1 auto;
+  width: ${props => 100 / props.totalOptions}%;
+  white-space: nowrap;
+  text-align: center;
+  user-select: none;
+  padding: ${props => (props.size === 'sm' ? compactPadding : basePadding)};
+  background-color: ${porcelain};
+  cursor: pointer;
+  font-size: ${getFontSize};
+  line-height: ${themeGet('lineHeights.normal')};
+  color: ${steel};
+  font-weight: ${bold};
+  transition: font-size 200ms ease-in-out;
+
+  border-left: 1px solid ${alto};
+  border-right: 1px solid ${alto};
+  border-top: 2px solid ${alto};
+  border-bottom: 2px solid ${alto};
+
+  &:first-of-type {
+    border-left: 2px solid ${alto};
+    border-top-left-radius: ${borderRadius};
+    border-bottom-left-radius: ${borderRadius};
+  }
+
+  &:last-of-type {
+    border-right: 2px solid ${alto};
+    border-top-right-radius: ${borderRadius};
+    border-bottom-right-radius: ${borderRadius};
+  }
+
+  ${HiddenInput}:checked + & {
+    color: ${charcoal};
+    border-color: ${blue};
+    background-color: ${white};
+    cursor: unset;
+  }
+
+  ${HiddenInput}:focus + & {
+    border-color: ${dusty};
+  }
+
+  ${HiddenInput}:disabled + & {
+    color: ${dusty};
+    font-weight: ${bold};
+    background-color: ${porcelain};
+    border-color: ${alto};
+    cursor: unset;
+  }
+`;

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -1,0 +1,44 @@
+# ButtonGroup
+
+<!-- STORY -->
+
+## Installation
+
+```shell
+$ yarn add roo-ui
+```
+
+## Example
+
+```js
+import { ButtonGroup } from 'roo-ui/components';
+
+const options = [
+  { label: 'One',   value: 'one' },
+  { label: 'Two',   value: 'two' },
+  { label: 'Three', value: 'three' },
+];
+
+const onChange = () => {
+  ...
+};
+
+export default (
+  <ButtonGroup name="group" value="two" options={options} size="sm" onChange={onChange} />
+);
+```
+
+## Properties
+
+| Name       | Description                                                    | Type       | Default | Required? |
+| ---------- | -------------------------------------------------------------- | ---------- | ------- | --------- |
+| `name`     | name assigned to each underlying option (radio) element        | `string`   | -       | ✔︎        |
+| `value`    | default/selected option                                        | `string`   | -       | ✔︎        |
+| `options`  | selectable options (each object must have `label` and `value`) | `array`    | -       | ✔︎        |
+| `onChange` | fn to execute on change                                        | `function` | -       | ✔︎        |
+| `disabled` | component children                                             | `boolean`  | false   |           |
+| `size`     | determine font and padding sizes                               | `string`   | base    |           |
+
+## Customization
+
+This component can be customized with [styled-system](https://jxnblk.com/styled-system) by passing props supported by [`<Flex />`](../Box/README.md), and [`<Box />`](../Box/README.md)

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonGroup /> renders correctly 1`] = `
+<Flex
+  aria-label="testButtonGroup"
+  role="radiogroup"
+>
+  <ButtonGroupOption
+    checked={true}
+    disabled={false}
+    id="buttonGroup_testButtonGroup_0"
+    key="0"
+    label="One"
+    name="testButtonGroup"
+    onChange={[Function]}
+    size="sm"
+    totalOptions={2}
+    value="one"
+  />
+  <ButtonGroupOption
+    checked={false}
+    disabled={false}
+    id="buttonGroup_testButtonGroup_1"
+    key="1"
+    label="Two"
+    name="testButtonGroup"
+    onChange={[Function]}
+    size="sm"
+    totalOptions={2}
+    value="two"
+  />
+</Flex>
+`;

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ButtonGroup /> renders correctly 1`] = `
-<Flex
+<ButtonGroupWrapper
   aria-label="testButtonGroup"
   role="radiogroup"
 >
@@ -29,5 +29,5 @@ exports[`<ButtonGroup /> renders correctly 1`] = `
     totalOptions={2}
     value="two"
   />
-</Flex>
+</ButtonGroupWrapper>
 `;

--- a/src/components/ButtonGroup/index.js
+++ b/src/components/ButtonGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from './ButtonGroup';

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -422,6 +422,26 @@ declare module 'roo-ui/components' {
     any
   >;
 
+  interface ButtonGroupOption {
+    label: string;
+    value: string;
+  }
+  interface ButtonGroupKnownProps extends FlexProps {
+    name: string;
+    value: string;
+    options: ButtonGroupOption[];
+    onChange: () => void;
+    disabled?: boolean;
+  }
+  export interface ButtonGroupProps
+    extends ButtonGroupKnownProps,
+      Omit<React.HTMLProps<HTMLDivElement>, keyof ButtonGroupKnownProps> {}
+  export const ButtonGroup: SC.StyledComponent<
+    ButtonGroupProps,
+    ButtonGroupProps,
+    any
+  >;
+
   interface CheckboxKnownProps extends BaseProps {}
   export interface CheckboxProps
     extends CheckboxKnownProps,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ export { default as BackgroundImage } from './BackgroundImage';
 export { default as Box } from './Box';
 export { default as LoadingIndicator } from './LoadingIndicator';
 export { default as Button } from './Button';
+export { default as ButtonGroup } from './ButtonGroup';
 export { default as Card } from './Card';
 export { default as Container } from './Container';
 export { default as ErrorMessage } from './ErrorMessage';

--- a/src/icons/index.d.ts
+++ b/src/icons/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'roo-ui/icons' {
+declare module "roo-ui/icons" {
   interface Icon {
     category: string;
     path: string;
@@ -64,9 +64,9 @@ declare module 'roo-ui/icons' {
   export const explore: Icon;
   export const extension: Icon;
   export const face: Icon;
-  export const favorite: Icon;
   export const favoriteBorder: Icon;
   export const favoriteStrike: Icon;
+  export const favorite: Icon;
   export const feedback: Icon;
   export const findInPage: Icon;
   export const findReplace: Icon;


### PR DESCRIPTION
## Description

Introduces a "ButtonGroup" component, borrowed/stolen from qantas-hotels-ui.
Styles modified slightly to better support more than two options.

TODO: I need help with border width for the "selected" option and avoiding overlap (been a while since I've been back in front-end land)

💁‍

## Related issues

To be used in https://app.clubhouse.io/qantasaccommodation/story/48915/booking-filter-tabs .
Can also replace "ButtonGroup" in qantas-hotels-ui

💪

## Looks like this

<!-- Insert GIF and/or screenshot(s) here -->

![Screen Shot 2020-11-11 at 6 54 03 pm](https://user-images.githubusercontent.com/7961537/98784806-c4efd380-244f-11eb-856a-7ab1b7987515.png)

🤨

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
