### PR TITLE
fix: correct ButtonGroupProps typedef

### DIFF
--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -19,7 +19,7 @@ const options = [
   { label: 'Three', value: 'three' },
 ];
 
-const onChange = () => {
+const onChange = (value) => {
   ...
 };
 

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -426,16 +426,20 @@ declare module 'roo-ui/components' {
     label: string;
     value: string;
   }
-  interface ButtonGroupKnownProps extends FlexProps {
+
+  interface ButtonGroupKnownProps extends Omit<FlexProps, 'size' | 'onChange'> {
     name: string;
     value: string;
     options: ButtonGroupOption[];
-    onChange: () => void;
     disabled?: boolean;
+    size?: string;
+    onChange: (value: string) => void;
   }
+
   export interface ButtonGroupProps
     extends ButtonGroupKnownProps,
       Omit<React.HTMLProps<HTMLDivElement>, keyof ButtonGroupKnownProps> {}
+
   export const ButtonGroup: SC.StyledComponent<
     ButtonGroupProps,
     ButtonGroupProps,


### PR DESCRIPTION
## Description

Corrects the typedef for ButtonGroup props. Specifically `onChange` and `size`

## Related issues

https://github.com/hooroo/roo-ui/pull/342

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
