### PR TITLE
fix: add textStyles to ts typedef

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,6 +53,6 @@ declare module 'roo-ui' {
       greys: KeyValue<string>;
       ui: KeyValue<string>;
     };
-    textStyles: NestedKeyValue<string>;
+    textStyles: KeyValue<NestedKeyValue<string>>;
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,10 @@ declare module 'roo-ui' {
     [key: string]: Value;
   }
 
+  export interface NestedKeyValue<Value> {
+    [key: string]: Value | NestedKeyValue<Value>;
+  }
+
   export const ThemeProvider: SC.ThemeProviderComponent<any>;
 
   export const theme: Theme;
@@ -49,5 +53,6 @@ declare module 'roo-ui' {
       greys: KeyValue<string>;
       ui: KeyValue<string>;
     };
+    textStyles: NestedKeyValue<string>;
   }
 }


### PR DESCRIPTION
## Description

"textStyles" was not part of the theme definition. I noticed this recently when converting some JS to TS in self-service (we add a couple of our own styles to the theme).

Also adds the `NestedKeyValue` type in there too, to support nested pseudo class defs (`:hover` and `:hidden`) in our additions  (thanks @ehyland for the suggestion).

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
