### PR TITLE
fix: use defaultProps in Flex component

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -7,12 +7,12 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -69,6 +69,7 @@ exports[`<Alert /> <Alert variant="error" /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -155,12 +156,12 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -217,6 +218,7 @@ exports[`<Alert /> <Alert variant="info" /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -303,12 +305,12 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -365,6 +367,7 @@ exports[`<Alert /> <Alert variant="success" /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -451,12 +454,12 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -513,6 +516,7 @@ exports[`<Alert /> <Alert.error /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -599,12 +603,12 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -661,6 +665,7 @@ exports[`<Alert /> <Alert.info /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -747,12 +752,12 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
 }
 
 .emotion-13 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-11 {
@@ -809,6 +814,7 @@ exports[`<Alert /> <Alert.success /> renders correctly 1`] = `
             className="emotion-15 emotion-10"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -895,12 +901,12 @@ exports[`<Alert /> contained renders correctly 1`] = `
 }
 
 .emotion-2 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-0 {
@@ -940,6 +946,7 @@ exports[`<Alert /> contained renders correctly 1`] = `
             className="emotion-4 emotion-5"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div
@@ -980,12 +987,12 @@ exports[`<Alert /> renders correctly 1`] = `
 }
 
 .emotion-2 {
-  padding-top: 32px;
-  padding-bottom: 32px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .emotion-0 {
@@ -1015,6 +1022,7 @@ exports[`<Alert /> renders correctly 1`] = `
             className="emotion-4 emotion-5"
           >
             <Flex
+              display="flex"
               py={4}
             >
               <div

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<ButtonGroup /> renders correctly 1`] = `
 <ButtonGroupWrapper
   aria-label="testButtonGroup"
+  display="flex"
   role="radiogroup"
 >
   <ButtonGroupOption

--- a/src/components/DatePicker/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
+++ b/src/components/DatePicker/components/CalendarDays/__snapshots__/CalendarDays.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CalendarDays /> renders correctly 1`] = `
-<CalendarDaysWrapper>
+<CalendarDaysWrapper
+  display="flex"
+>
   <CalendarDay
     _isMockFunction={true}
     disabled={false}

--- a/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
+++ b/src/components/DatePicker/components/CalendarNav/__snapshots__/CalendarNav.test.js.snap
@@ -78,7 +78,9 @@ exports[`<CalendarNav /> renders correctly 1`] = `
     }
   }
 >
-  <Wrapper>
+  <Wrapper
+    display="flex"
+  >
     <div
       className="emotion-22 emotion-23"
     >

--- a/src/components/DatePicker/components/CalendarWeekdays/__snapshots__/CalendarWeekdays.test.js.snap
+++ b/src/components/DatePicker/components/CalendarWeekdays/__snapshots__/CalendarWeekdays.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CalendarWeekdays /> renders correctly 1`] = `
-<CalendarWeekdaysWrapper>
+<CalendarWeekdaysWrapper
+  display="flex"
+>
   <CalendarWeekday
     key="72018S0"
   >

--- a/src/components/Flex/Flex.js
+++ b/src/components/Flex/Flex.js
@@ -15,7 +15,6 @@ const flexFlow = style({
 });
 
 const Flex = styled(Box)`
-  display: flex;
   ${alignItems} ${alignContent} ${justifyContent} ${flexWrap} ${flexDirection} ${flexFlow};
 `;
 
@@ -27,6 +26,10 @@ Flex.propTypes = {
   ...flexWrap.propTypes,
   ...flexDirection.propTypes,
   ...flexFlow.propTypes,
+};
+
+Flex.defaultProps = {
+  display: 'flex',
 };
 
 export default Flex;

--- a/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.test.js.snap
+++ b/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<ModalFooter /> renders correctly 1`] = `
 <Flex
   alignItems="center"
+  display="flex"
   justifyContent="center"
   pb={11}
   px={11}

--- a/src/components/StarRating/__snapshots__/StarRating.test.js.snap
+++ b/src/components/StarRating/__snapshots__/StarRating.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<StarRating /> renders correctly 1`] = `
 <Flex
   aria-label="1 out of 5 rating"
+  display="flex"
   itemType="http://schema.org/AggregateRating"
   title="1 out of 5 rating"
 >


### PR DESCRIPTION
We are currently hard coding the display value to `flex` in the `Flex` component. This is what is required 95% of the time, but it limits the ability to show and hide the component across breakpoints. This change to using defaultProps rather than hard coded properties will make it possible to hide a flexbox on the lowest break point and show it on all others. As well cater to other rare, but useful, requirements.

This would not work before, but is possible after this PR.

```js
<Flex display={['none', 'flex']}>
  {children}
</Flex>
```