### PR TITLE
fix: adding a focus outline to the generic button component

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -51,6 +51,7 @@ const Button = styled.button`
 
   &:focus {
     box-shadow: ${themeGet('shadows.focus')};
+    outline: ${themeGet('borders.2')} ${themeGet('colors.brand.secondary')};
   }
 
   &:disabled {

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -50,8 +50,7 @@ const Button = styled.button`
   }
 
   &:focus {
-    box-shadow: ${themeGet('shadows.focus')};
-    outline: ${themeGet('borders.2')} ${themeGet('colors.brand.secondary')};
+    box-shadow: 0 0 0 2px ${themeGet('colors.brand.secondary')};
   }
 
   &:disabled {

--- a/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -44,6 +44,7 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 
 .emotion-0:focus {
   box-shadow: 0 0 2px 2px #999999;
+  outline: 2px solid #8DE2E0;
 }
 
 .emotion-0:disabled {
@@ -126,6 +127,7 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 
 .emotion-0:focus {
   box-shadow: 0 0 2px 2px #999999;
+  outline: 2px solid #8DE2E0;
 }
 
 .emotion-0:disabled {
@@ -205,6 +207,7 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 
 .emotion-0:focus {
   box-shadow: 0 0 2px 2px #999999;
+  outline: 2px solid #8DE2E0;
 }
 
 .emotion-0:disabled {

--- a/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
+++ b/src/components/OutlineButton/__snapshots__/OutlineButton.test.js.snap
@@ -43,8 +43,7 @@ exports[`<OutlineButton /> primary renders correctly 1`] = `
 }
 
 .emotion-0:focus {
-  box-shadow: 0 0 2px 2px #999999;
-  outline: 2px solid #8DE2E0;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .emotion-0:disabled {
@@ -126,8 +125,7 @@ exports[`<OutlineButton /> renders correctly 1`] = `
 }
 
 .emotion-0:focus {
-  box-shadow: 0 0 2px 2px #999999;
-  outline: 2px solid #8DE2E0;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .emotion-0:disabled {
@@ -206,8 +204,7 @@ exports[`<OutlineButton /> rounded renders correctly 1`] = `
 }
 
 .emotion-0:focus {
-  box-shadow: 0 0 2px 2px #999999;
-  outline: 2px solid #8DE2E0;
+  box-shadow: 0 0 0 2px #8DE2E0;
 }
 
 .emotion-0:disabled {


### PR DESCRIPTION
## Description

Adding a focus outline to the default button component. We are updating accessibility in the QH site and the box-shadow on focus is not sufficient to distinguish the button as being focused.

This focus styling is the same styling used for `<NakedButton />`

💁‍


## Looks like this
OLD:
![Screen Shot 2021-01-04 at 10 33 38 am](https://user-images.githubusercontent.com/1169014/103491478-5724be80-4e78-11eb-9edb-ccb95f27abb9.png)

NEW:
![Screen Shot 2020-12-31 at 11 48 54 am](https://user-images.githubusercontent.com/1169014/103388808-351cfa80-4b5f-11eb-8193-b1ba038d37da.png)


🤨

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [ ] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
