### PR TITLE
fix: distinguish button group focus state from selected state

### DIFF
--- a/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
+++ b/src/components/ButtonGroup/ButtonGroupOption/__snapshots__/ButtonGroupOption.test.js.snap
@@ -44,6 +44,10 @@ exports[`<ButtonGroupOption /> renders correctly 1`] = `
   z-index: 2;
 }
 
+.emotion-1:focus + .emotion-2 {
+  z-index: 2;
+}
+
 .emotion-1:disabled + .emotion-2 {
   cursor: unset;
 }

--- a/src/components/ButtonGroup/ButtonGroupOption/primitives.js
+++ b/src/components/ButtonGroup/ButtonGroupOption/primitives.js
@@ -62,7 +62,8 @@ export const ButtonLabel = styled.label`
   }
 
   ${HiddenInput}:focus + & {
-    border-color: ${dusty};
+    border-color: ${themeGet('colors.ui.focusColor')};
+    z-index: 2;
   }
 
   ${HiddenInput}:disabled + & {

--- a/src/theme.js
+++ b/src/theme.js
@@ -41,6 +41,7 @@ const ui = {
   linkHover: namedColors.maroon,
   success: namedColors.green,
   successBackground: namedColors.lightGreen,
+  focusColor: '#0E62C9',
 };
 
 const colors = {


### PR DESCRIPTION
## Description

Button group uses a dusty grey border outline to denote that the element has focus. 

This is insufficient for focus, as the grey border and white background do not have sufficient colour contrast.

Instead, we will use a bright blue colour, as supplied by Kym. This should only display the blue outline on keyboard focus and not when the element is clicked.

💁‍

## Looks like this

![button_group_focus](https://user-images.githubusercontent.com/1169014/108926345-5519f780-7692-11eb-8d68-38701a89a179.gif)


🤨

---

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [ ] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [ ] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
