### PR TITLE
fix: add missing input props to typescript definition

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -202,7 +202,15 @@ declare module 'roo-ui/components' {
       Omit<React.HTMLProps<HTMLImageElement>, keyof ImageKnownProps> {}
   export const Image: SC.StyledComponent<ImageProps, ImageProps, any>;
 
-  interface InputKnownProps extends BaseProps, SS.SpaceProps {
+  interface InputKnownProps
+    extends BaseProps,
+      SS.SpaceProps,
+      SS.ColorProps,
+      SS.FontSizeProps,
+      SS.LineHeightProps,
+      SS.BorderProps,
+      SS.BorderColorProps,
+      SS.TextAlignProps {
     error?: boolean;
     underline?: boolean;
   }


### PR DESCRIPTION
- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
