### PR TITLE
Update `Modal` component exports and typing

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,1 +1,7 @@
-export { default, ModalGlobalStyle } from './Modal';
+export {
+  default,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalGlobalStyle,
+} from './Modal';

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -292,6 +292,7 @@ declare module 'roo-ui/components' {
   };
 
   export interface ModalProps extends ReactModal.Props {
+    isOpen: boolean;
     width?: number | string;
   }
   interface ModalHeaderProps extends BoxProps {


### PR DESCRIPTION
## Description

Users of `create-react-app` will notice a linting issue when consuming the `Modal` component's `header`, `body` or `footer` properties. Specifically, `create-react-app`'s eslint rule `react/jsx-pascal-case` expects all component names to be PascalCase or SCREAMING_SNAKE_CASE.

For example, `Modal.body` does not satisfy this. `Modal` now exports `ModalHeader`, `ModalBody` and `ModalFooter` so users of this linting rule can safely consume them.

Secondly, the `isOpen` prop was missing from the `ModalProps` interface - so users of typescript would notice a compilation error when trying to use the `Modal` component