### PR TITLE
fix: files ignore glob for icon source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "types": "lib/index.d.ts",
   "module": "esm/",
   "files": [
-    "!**/icons/**/",
     "lib/",
     "esm/",
     "assets/",
@@ -20,7 +19,8 @@
     "icons/",
     "logos/",
     "*.d.ts",
-    "!*/icons/*/",
+    "!esm/icons/**/*.svg",
+    "!lib/icons/**/*.svg",
     "!*.test.*",
     "!*.story.*"
   ],


### PR DESCRIPTION
## Description

After node upgrade (`roo-ui@0.91.2`), `icons/index.js` was being excluded from bundle.

This PR updates the `package.files` ignore glob to be more specific  

**PR check-list**

🚨 **IMPORTANT:** Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository first! 👀

- [x] You've requested a review from at least ONE person. Preferably a roo-ui maintainer ([Angus](https://github.com/angusfretwell), [Philip](https://github.com/philipwindeyer), [Eric](https://github.com/eneo5541), [Mike](https://github.com/memcc), or [Long](https://github.com/KieraDOG)).
  - Note: If your PR has not been reviewed within two days of requesting a review, feel free to seek reviews from other [team members of Qantas Hotels](https://github.com/orgs/hooroo/people).
- [x] Your final merge commit message is in the format `<type>(<scope>): <description>` as per [the contributing guide](https://github.com/hooroo/roo-ui/blob/master/.github/CONTRIBUTING.md#commit-naming)
  - Example: `fix(dependencies): minor version bump to resolve security vulnerability in set-value`
